### PR TITLE
v0.0.2: agent ergonomics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,18 @@ removed) verbatim, for provenance only — don't treat them as current.
 - **On-disk schema is frozen.** Pipeline sink names (`nodes`, `children`,
   `text`, `instances_of`, `styled_by`, `bound_to`, `by_type`,
   `components`, `component_sets`, `styles`, `variables`,
-  `variable_collections`, `meta`, `proxy_cache`) are on-disk schema —
-  renaming one changes what store directory an unmodified binary can
-  open. `Id`/`Rec` are append-only enums: postcard encodes variant
-  indices positionally, so a new variant goes at the end of each enum,
-  never inserted or reordered.
+  `variable_collections`, `meta`, `proxy_cache`, `mirror_config`,
+  `images`) are on-disk schema — renaming one changes what store
+  directory an unmodified binary can open. `Id`/`Rec` are append-only
+  enums: postcard encodes variant indices positionally, so a new variant
+  goes at the end of each enum, never inserted or reordered.
+- **New record kind, not a wider struct.** Postcard encodes struct fields
+  positionally too, so adding a field to an existing `Rec` payload struct
+  (`FileMeta`, `NodeRec`, …) breaks decoding of every store already on
+  disk, while appending an `Id`/`Rec` variant does not. When a feature
+  needs new stored state, add a new record kind (and its own appended
+  sink) rather than widening an existing one — `MirrorConfig` is the
+  worked example.
 - **`fold`/`bogkit` is upstream.** Never vendored, never patched — consume
   only the pinned git dependency's public API.
 - **Gates for any change:** `cargo test`, `cargo clippy --no-deps
@@ -28,6 +35,12 @@ removed) verbatim, for provenance only — don't treat them as current.
 - **No new dependencies without a written justification in the PR.**
 - **Fixtures are synthetic only** — nothing derived from real client
   files.
+- **License: AGPL-3.0-only, no per-file headers (yet).** figmog's own
+  code is AGPL-3.0-only as of v0.0.2; the v0.0.1 snapshot stays MIT.
+  Per-file license headers were deliberately skipped. Revisit both that
+  decision and a contributor license agreement if the project starts
+  taking outside contributions, since relicensing or dual-licensing later
+  needs the rights a CLA collects.
 - **Pin-bump checklist.** Bumping `fold`'s pinned `rev` in `Cargo.toml`
   isn't just a version bump: `cli/mod.rs`'s `open_store_checked` matches
   the substring `"Locked"` against a caught panic's payload to distinguish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "figmog"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "figmog"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 license = "AGPL-3.0-only"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@
 name = "figmog"
 version = "0.0.1"
 edition = "2024"
-license = "MIT"
+license = "AGPL-3.0-only"
 
 [dependencies]
 fold = { git = "https://github.com/flowercomputers/bogkit", rev = "20f2ca50d5d06f51edfe8b8570c0fb48caf9eb81" }

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,661 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2026 sanctuary computer
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,518 +1,270 @@
 # figmog
 
-A fold-backed local mirror of one or more Figma files: `pull` fetches a
-file once and keeps materialized indexes in a local database, so every
-read after that — search, tree walks, component/style/variable queries —
-answers from local storage in milliseconds, spending zero Figma API calls
-and hitting zero rate limits. `figmog serve` runs the same engine as an
-MCP stdio server with its own poll loop, plus a cached proxy to Figma's
-native desktop MCP server, so it can be the only Figma MCP an agent needs
-to connect.
+figmog is a superset of the Figma MCP surface: a local, instantly-queryable
+mirror of your Figma files built for high-performance design agents.
 
-See [`docs/SPEC.md`](docs/SPEC.md) for the full current-state spec
-(architecture, data model, sync semantics, the MCP tool surface, the
-cached proxy, variables, and the determinism/schema-stability contracts).
+One node read: 0.055ms from the mirror, 972.6ms through Figma's REST API in
+the same run. That is 17,657x faster. figmog sustained 149 requests a second
+where Figma's Tier-1 file budget is about 10 requests a minute, and
+re-syncing a file nobody had edited cost 4.6ms and wrote nothing. Measured
+2026-08-17 against a real 5,339-node production file; the full run is
+[further down](#the-benchmark-run).
 
-## License
+## Quick start
 
-figmog's own code is MIT (see [`LICENSE`](LICENSE)). It depends on
-[`fold`](https://github.com/flowercomputers/bogkit) via a pinned git
-dependency; upstream `bogkit` currently ships with no license file.
-Building and running figmog locally from source is fine, but **broader
-redistribution of binaries that embed `fold` waits on upstream adding a
-license** — the release workflow lands ready, but publishing beyond this
-repo's own testing releases is a deliberate, separate decision.
-
-## Install
-
-### From a release binary
-
-Download the tarball for your platform, plus `SHA256SUMS`, from
-[Releases](https://github.com/sanctuarycomputer/figmog/releases)
-(`figmog-<version>-<target>.tar.gz` — `aarch64-apple-darwin`,
-`x86_64-apple-darwin`, or `x86_64-unknown-linux-gnu`), then:
+### 1. Get the binary
 
 ```console
 $ tar xzf figmog-<version>-<target>.tar.gz
 $ chmod +x figmog
-$ ./figmog --help
+$ xattr -d com.apple.quarantine ./figmog   # macOS only, see Install
 ```
 
-**Verify the download (optional but recommended).** `SHA256SUMS`
-covers all three platform tarballs in a release; check the one you
-downloaded against it:
+Tarballs live on the
+[releases page](https://github.com/sanctuarycomputer/figmog/releases).
 
-```console
-$ shasum -a 256 -c SHA256SUMS --ignore-missing   # macOS
-$ sha256sum -c SHA256SUMS --ignore-missing        # Linux
-```
-
-Either should print `figmog-<version>-<target>.tar.gz: OK`.
-
-**Linux: glibc requirement.** The `x86_64-unknown-linux-gnu` binary is
-built on Ubuntu 24.04 and requires glibc ≥ 2.39; on older distros, build
-from source instead (see below).
-
-**macOS: unsigned binary.** These builds are not code-signed or notarized
-(no Apple Developer account in the loop yet), so Gatekeeper will refuse
-to run the downloaded binary until you clear the quarantine attribute
-once:
-
-```console
-$ xattr -d com.apple.quarantine ./figmog
-```
-
-### From source
-
-Needs a Rust toolchain and network access (the build fetches `fold` from
-its pinned git rev):
-
-```console
-$ git clone https://github.com/sanctuarycomputer/figmog.git
-$ cd figmog
-$ cargo build --release
-$ ./target/release/figmog --help
-```
-
-Every `figmog ...` example below assumes a `figmog` binary on your
-`PATH` (a release download, or `./target/release/figmog` after a
-from-source build) — substitute `cargo run --release --` in place of
-`figmog` if you'd rather run straight from a source checkout without
-installing the binary anywhere, e.g. `cargo run --release -- pull <url>`.
-
-## Quick start
-
-```console
-$ export FIGMA_TOKEN=figd_…            # figma.com → settings → security → personal access tokens
-$ figmog pull "https://www.figma.com/design/<key>/<name>"
-$ figmog search "pricing card"
-$ figmog serve                          # MCP server with its own poll loop, in another terminal
-```
-
-After the first `pull`, figmog remembers the file key (in `.figmog/current`
-under the current directory), so every later command — including all the
-read commands below — can drop the file argument.
-
-## Commands
-
-Read commands never touch the network: they open the local store and read
-one snapshot, and always print machine-readable JSON on stdout (pretty-
-printed); errors always print `{"error": ...}` on stderr. `--db <path>`
-(global) overrides the store location (default `.figmog/<file-key>/db`).
-
-| command | reads | behavior |
-|---|---|---|
-| `figmog pull [file] [--from-file <json>] [--fresh]` | — | sync now; prints a churn summary (`+added ~changed -removed`). `file` is optional after the first pull. `--from-file` ingests a saved `GET /v1/files/:key` response instead of the network (offline ingestion, and what keeps the CLI tests hermetic). `--fresh` wipes the store **and the proxy response cache** and rebuilds from scratch. |
-| `figmog serve [file...] [--interval N] [--no-watch] [--upstream <url>] [--no-upstream]` | — | MCP stdio server (see "Use from agents (MCP)" below); polls for changes itself (`--interval` seconds, default 10) and pulls only on an actual change; `--no-watch` disables that poll loop for a read-only, offline server; `--no-upstream` disables the cached proxy to Figma's native desktop MCP server |
-| `figmog tools [--upstream <url>] [--no-upstream]` | — | list every tool `figmog serve` would expose for this mirror: name, source (`local`/`upstream`), and whether it's cache-capable. Never opens the store — works with no established mirror at all. |
-| `figmog call <tool> [--args '<json>'] [--upstream <url>] [--no-upstream]` | — | invoke any tool by name through the same dispatch `figmog serve` uses — local `figmog_*` tools and, when attached, any upstream tool |
-| `figmog status` | meta + nodes | file name, version, last modified, node count |
-| `figmog pages` | by_type + nodes | list CANVAS pages (id, name) |
-| `figmog tree [id] [--depth N]` | children + nodes (+ by_type to find the root) | indented outline: `name  [type]  id`; root defaults to the DOCUMENT node |
-| `figmog get <id> [--children]` | nodes (+ children) | the full `raw` JSON of a node; `--children` inlines one level of child summaries |
-| `figmog find --type <TYPE> [--page <id>]` | by_type + nodes | nodes by type, optional page filter |
-| `figmog search <query> [-n N]` | Bm25 + nodes | ranked hits (default 10): score, id, type, name, page, text snippet |
-| `figmog instances <id\|key\|name>` | nodes + instances_of + components + component_sets | resolve the argument to a component (by node id, global key, or a unique component/component-set name — a set name expands to all its variants), list instance nodes |
-| `figmog components` | components + component_sets + nodes | design-system inventory: component sets with their variant axes, standalone components |
-| `figmog styles [--type <t>] [--values]` | styles + styled_by (+ nodes) | styles with usage counts; `--values` derives each style's definition from a consumer node (§ below) |
-| `figmog uses <id>` | styled_by / bound_to + nodes | nodes using a style id or bound to a variable id |
-| `figmog vars [id]` | nodes + variables + variable_collections | variables: authoritative record if imported, else inferred value(s) + binding sites |
-| `figmog import-variables <path>` | — | upsert variable/collection records from a variables export (see "Variables") |
-| `figmog stats` | nodes + by_type + components + component_sets + styles + variables | node counts by type and by page, component/set/style/variable totals, text-node count, max tree depth — whole-file structural queries the API can't offer at all |
-| `figmog path <id>` | nodes | ancestor chain root→node: `[{id, name, type}]` |
-| `figmog text [--page <id>]` | by_type + nodes | every TEXT node's `(id, characters, page_id)`, sorted by id |
-| `figmog where --pointer </p> [--equals <json>] [--page <id>]` | nodes | nodes whose raw JSON matches an RFC 6901 `pointer`, optionally filtered by `equals` (parsed as JSON, falling back to a bare string so `--equals VERTICAL` works) |
-| `figmog at --x N --y N` | nodes | nodes whose absolute bounds contain the point, sorted by area ascending (deepest/smallest first) |
-
-Node ids accept both `12:34` and `12-34` forms everywhere. Auth is a
-personal access token from `FIGMA_TOKEN`. Since `pull` and `serve`'s own
-poll loop are the only things that touch the network, everything else
-works fine with no token set as long as a store already exists.
-
-## How sync works
-
-`figmog serve`'s built-in poll loop polls the cheap `GET
-/v1/files/:key/meta` endpoint (Tier 3) every `--interval` and only spends a
-Tier-1 `GET /v1/files/:key` fetch — the expensive, rate-limited call — when
-the file's content-modification watermark actually changes. Every fetch,
-whether from `pull` or that poll loop, flows through fold's `KeyedStream`
-upsert-diff: re-syncing a byte-identical node is a no-op through the whole
-pipeline (zero graph churn, zero index writes), so a spurious trigger or a
-repeated `pull` costs one Tier-1 fetch and nothing else. Since the
-November 2025 rate-limit overhaul, file endpoints are capped around **10
-requests/min on the free (Starter) plan**, and there is no delta API —
-this polling design is what makes that budget workable for an agent that
-wants to treat the file as live. The Tier-3 meta poll itself is capped
-around **50 requests/min on Starter**, well above any sane `--interval`.
-
-**Freshness is polling, not push.** figmog only learns a file changed the
-next time it polls (or the next explicit `pull`) — there is no webhook or
-subscription, so a change can take up to `--interval` seconds to be
-reflected (Figma's own `FILE_UPDATE` webhook is Enterprise-only and
-debounced up to 30 minutes even where it exists, so polling a cheap
-Tier-3 endpoint is both simpler and faster in practice).
-
-## Use from agents (MCP)
-
-**figmog is the only Figma MCP an agent needs to connect.** `figmog serve`
-is one process — fjall is single-writer, so a second writer would fight it
-for the store lock — that owns the mirror, polls for changes itself, and
-(unless `--no-upstream`) also attaches
-Figma's native desktop MCP server as a **cached proxy**: `tools/list`
-merges figmog's 19 local `figmog_*` tools with every tool the desktop
-server advertises, verbatim, so an agent gets one server, one connection,
-and the full native tool surface (`get_design_context`, `get_screenshot`,
-`get_variable_defs`, code-generation tools, …) without figmog reimplementing
-any of it. `figmog serve` also mirrors more than one file in one process —
-see "Multiple files" below.
-
-```console
-$ claude mcp add figmog -- /absolute/path/to/figmog serve "https://www.figma.com/design/<key>/<name>"
-```
-
-Read-only / offline, once a store already exists (no `FIGMA_TOKEN`
-needed):
-
-```console
-$ claude mcp add figmog -- /absolute/path/to/figmog serve --db .figmog/<key>/db --no-watch
-```
-
-`--interval N` (default 10s) controls the poll cadence of `serve`'s
-built-in poll loop.
-
-**Single-writer constraint:** because fjall allows only one open handle per
-store, `figmog serve` holds an exclusive lock on its `--db` for as long as
-it runs. A CLI read against the *same* store while `serve` is up —
-`figmog status`, `figmog search`, `figmog call figmog_status`, and any
-other command that opens the store — fails fast with a clean `store is
-locked` error rather than a raw panic; drive the running server through
-its own MCP tool calls instead, or stop `serve` first. (`figmog tools`
-never opens the store, so it works fine even while `serve` is running.)
-The same applies to `serve` itself: starting a second `figmog serve`
-against a store one of them already owns fails with the same clean
-message rather than a raw panic.
-
-### Multiple files
-
-`figmog serve [FILE]...` takes zero or more Figma file URLs/keys at
-startup — one process can mirror several files. Every local `figmog_*`
-tool gains an optional `file` argument (a URL or bare key, parsed the same
-way as the CLI's own file arguments): pass it to route the call at a
-specific mirror, auto-opening it (spending one Tier-1 pull) the first time
-an agent references it; omit it and the call answers from the *default*
-file — the first `FILE` given at startup, or whichever got mirrored first
-if none were.
-
-```console
-$ claude mcp add figmog -- /absolute/path/to/figmog serve
-```
-
-With more than one mirrored file, the poll loop round-robins: each tick
-polls one session's Tier-3 meta endpoint, and the wait between ticks is
-`--interval` split evenly across the mirrored files, floored at 2s — so
-with many files the loop still tops out at 30 Tier-3 requests/min (well
-under the ~50 req/min Starter cap above), it just polls each individual
-file less often as the file count grows.
-
-Zero files at startup is valid and needs no `FIGMA_TOKEN` up front — the
-server starts empty and mirrors files as an agent references them by URL.
-This is the shape to reach for with `claude mcp add` when you don't want
-to commit to one file ahead of time; passing one or more files at startup
-(as in the single-file examples above) still works exactly as before, and
-the first one becomes the default so every existing single-file tool call
-still needs no `file` argument at all.
-
-Two tools manage the mirror set directly:
-
-- `figmog_open {file}` — mirror a file now (spends one Tier-1 pull);
-  returns its churn and node count. Creates the mirror if it's new, or
-  re-syncs it if already mirrored.
-- `figmog_files` — list every mirrored file: key, name, version, node
-  count, last synced time, and which one (if any) is the default.
-
-**Proxied tools caveat:** the desktop server operates on the file open in
-the Figma app; the `file` argument does not route proxied tools. A `file`
-argument sent on a non-`figmog_*` call is simply ignored — the desktop
-server has no concept of "which file", so
-`get_code`/`get_design_context`/etc. always answer for whatever file is
-open in the Figma app, independent of any mirror `figmog serve` manages.
-
-**Accepted divergence:** `.figmog/current` — the file `pull`/plain `figmog
-serve <file>` remember so later CLI commands can drop the file argument —
-is only refreshed by a startup pull that actually *ran*. A startup file
-whose store is already populated (including every `--no-watch` invocation,
-which never pulls at startup at all) leaves `.figmog/current` untouched;
-only a genuine network pull — the initial pull against an empty store, or
-a later poll-tick pull — writes it.
-
-CLI commands (`pull`, `status`, and the rest) are unchanged and
-still address exactly one file via `--db`/`.figmog/current` — multi-file
-addressing is a `serve` capability only (no CLI multi-file addressing, no
-cross-file queries, no idle-session eviction — a session opened stays
-open for the process's life).
-
-### The cached proxy
-
-Proxying targets **paid Dev/Full seats**: it requires the Figma desktop
-app to be running with its Dev Mode MCP server enabled (streamable HTTP,
-default `http://127.0.0.1:3845/mcp`). At startup figmog probes it; on
-success, every non-`figmog_*` tool call is forwarded there. On failure
-(desktop app not running, no Dev/Full seat, wrong URL), figmog logs one
-stderr line and falls back to local-only tools for the rest of the
-process — no mid-session re-probe, so restart `figmog serve` once the
-desktop server is reachable to attach it.
-
-- `--upstream <url>` overrides the desktop server's URL.
-- `--no-upstream` disables proxying entirely — figmog serves its 19
-  `figmog_*` tools only.
-- **Namespace rule:** `figmog_*` tools are always local; every other tool
-  name is always proxied. If the desktop server ever advertised a tool
-  named `figmog_*`, figmog would drop it and log a warning rather than
-  let it collide — this can't happen with figmog's own registry, but a
-  live desktop server's tool list is outside figmog's control.
-- **Cacheable rule:** a proxied call is served from (and written to) a
-  version-keyed response cache when its tool name starts `get_`/`list_`
-  **and** its arguments carry an explicit node id (`nodeId`, `node_id`,
-  or `id`, as a string) — e.g. `get_code` with a `nodeId` hits the cache
-  on a repeat call for the same node, as long as the mirror's file
-  version hasn't changed since. Selection-based calls (no explicit node
-  id) are always forwarded live. A version bump (from a pull, whether the
-  poll loop's or `figmog_sync`'s) evicts every cache row tagged with the
-  old version. A cache-write failure (practically unreachable in
-  practice) is logged to stderr but never fails the call — the upstream
-  response already succeeded and still reaches the client.
-- **Only two things spend Figma's API/rate budget:** `figmog_sync` (a
-  forced pull) and any proxied, native-named tool call that reaches the
-  desktop server (a cache hit doesn't). Every `figmog_*` read tool is
-  free, whether or not the proxy is attached.
-- A successful proxied call to a tool that isn't `get_*`/`list_*` (e.g. a
-  code-connect write) may have changed the file, so figmog schedules an
-  immediate meta-poll rather than waiting for the next `--interval` tick
-  (skipped in `--no-watch` mode, which has no poll loop to schedule).
-- `pull --fresh` wipes the store **and** the proxy response cache — a
-  totally clean rebuild.
-
-### CLI parity
-
-Every tool figmog serves — local or proxied — is also reachable from the
-CLI, so you can inspect or drive the exact same dispatch without an MCP
-client:
-
-```console
-$ figmog tools                              # merged list: name, source, cacheable
-$ figmog call figmog_search --args '{"query": "pricing card"}'
-$ figmog call get_code --args '{"nodeId": "1:2"}'   # proxied, cached by version
-```
-
-Both accept `--upstream <url>` / `--no-upstream`, probed fresh per
-invocation (no persistent connection between CLI calls). There are
-deliberately no bespoke subcommands for upstream tools — Figma's tool
-list churns; `figmog call` is the stable, generic surface.
-
-`figmog call` requires a resolved mirror — an established
-`.figmog/current` (from a prior `pull`) or an explicit `--db <path>` —
-since local tool dispatch reads the store; with neither, it exits 1 with
-`no mirror here — run figmog pull <file-url> first`. `figmog tools` never
-reads the store, so it works with no resolved mirror at all.
-
-### Core read tools
-
-Each mirrors a CLI read command one-to-one and answers instantly from the
-local store — zero Figma API cost, zero rate-limit exposure. Every tool
-below also takes an optional `file` argument (URL or key) routing the call
-at a specific mirror — see "Multiple files" above.
-
-| tool | input | reads |
-|---|---|---|
-| `figmog_status` | — | file name, version, last modified, node count |
-| `figmog_pages` | — | list CANVAS pages (id, name), in document order |
-| `figmog_tree` | `id`, `depth` | subtree outline rooted at a node; root defaults to the document |
-| `figmog_node` | `id` (required), `children` | full `raw` JSON of one node; `children` inlines a one-level summary |
-| `figmog_find` | `type` (required), `page` | nodes by Figma node type, optionally scoped to one page |
-| `figmog_search` | `query` (required), `limit` | BM25 search over layer names and text content |
-| `figmog_instances` | `target` (required) | instances of a component, resolved by node id, key, or (set) name |
-| `figmog_components` | — | design-system inventory: sets with variant axes, standalone components |
-| `figmog_styles` | `type`, `values` | styles with usage counts; `values` derives each definition from a consumer |
-| `figmog_uses` | `id` (required) | nodes using a style id or bound to a variable id |
-| `figmog_vars` | `id` | variables: authoritative if imported, else inferred from bindings |
-| `figmog_sync` | — | forces one pull and returns the churn — the **only** tool that spends Figma's rate budget |
-
-### Whole-file structural queries
-
-The local mirror's unfair advantage: full-file answers no rate-limited API
-surface could offer, each a read-only scan/join over the same indexes.
-Every one has a matching CLI subcommand, so the CLI/tool surface stays
-one-to-one, and (like the core read tools above) each also takes an
-optional `file` argument.
-
-| tool | CLI equivalent | input | answer |
-|---|---|---|---|
-| `figmog_stats` | `figmog stats` | — | node counts by type/page, component/set/style/variable totals, text-node count, max tree depth |
-| `figmog_path` | `figmog path <id>` | `id` (required) | ancestor chain root→node as `[{id, name, type}]` |
-| `figmog_text` | `figmog text [--page id]` | `page` | every TEXT node's `(id, characters, page_id)`, sorted by id |
-| `figmog_where` | `figmog where --pointer /p --equals <json>` | `pointer` (required, RFC 6901 into `raw`), `equals`, `page` | matching `[{id, name, type, page_id, value}]`, sorted by id |
-| `figmog_at` | `figmog at --x N --y N` | `x`, `y` (required) | nodes whose `abs_bounds` contain the point, sorted by area ascending (deepest/smallest first) |
-
-### `figmog_open` / `figmog_files`
-
-Manage the multi-file mirror set directly (see "Multiple files" above):
-
-| tool | input | answer |
-|---|---|---|
-| `figmog_open` | `file` (required) | mirror a file now (spends one Tier-1 pull); creates or re-syncs it; returns churn + node count |
-| `figmog_files` | — | every mirrored file: key, name, version, node count, last synced time, and which one is the default |
-
-That's 12 core read tools + 5 structural queries + 2 multi-file
-management tools = **19 `figmog_*` tools** in total.
-
-### Relationship to Figma's official MCP server
-
-figmog **replaces** the official desktop MCP server in an agent's config —
-connect figmog instead of it, not alongside it. figmog's `initialize`
-response carries steering `instructions` telling an agent to reach for
-figmog for everything:
-
-> figmog is your Figma server: a local, instant mirror of one Figma file
-> plus a cached proxy to Figma's native capabilities. Call figmog for
-> everything Figma-related. figmog_* tools answer from the local mirror
-> at zero API cost; native-named tools (get_*, …) go to Figma, cached by
-> file version where possible. Pass the Figma file URL as the `file`
-> argument when you have one; figmog mirrors files on first reference.
-
-Every figmog-native tool lives in the `figmog_*` namespace, so it never
-collides by name with a proxied tool; local tools only ever read the
-mirror and only ever write to it via `figmog_sync`, the one local tool
-that spends Figma's Tier-1 rate budget (a forced pull) — every other
-local tool call is instant, free, and backed by the same
-fold-materialized indexes the CLI reads. Proxied tools go through the
-cache described above. `--no-upstream` recovers the "second, separate
-server" shape if that's ever preferable — figmog's 19 `figmog_*` tools
-alongside Figma's own, unrelated MCP connection.
-
-## Variables
-
-**Enterprise auto-sync (automatic, zero setup).** Every network `pull`
-additionally calls `GET /v1/files/:key/variables/local` — the Enterprise
-REST endpoint for full-fidelity variable and collection records:
-collections, modes (e.g. light/dark), per-mode values, descriptions,
-scopes. When it succeeds, those records are folded into the same sync and
-kept live: a variable removed upstream is swept on the next pull, exactly
-like a deleted node. On non-Enterprise plans the endpoint 403s (or 404s)
-and the call is **silently skipped** — no error, no flag to set — falling
-back to the two paths below. `--from-file` pulls never call it at all
-(no network involved).
-
-Below that, variables are supported through two complementary fallback
-paths that work on every plan:
-
-**Path 1 — mirrored bindings + inference (always on, zero setup).** Every
-variable-bound property in the file JSON carries a `boundVariables`
-reference, and Figma bakes the resolved concrete value into the same node
-next to it. figmog scans every node for these bindings at every depth and
-inverts them into a `bound_to` index. `figmog vars` aggregates at read
-time: for each variable id, every binding site (node + property path) and
-the observed value(s) baked in there. This covers each variable's
-**default-mode value**; values from a non-default mode appear only where a
-frame explicitly overrides its mode.
-
-**Path 2 — manual import (optional).** `figmog import-variables
-<export.json>` upserts the same full-fidelity variable and collection
-records the Enterprise auto-sync produces, by hand. It accepts two shapes:
-the Enterprise REST `variables/local` response (the same shape auto-sync
-already ingests, useful for a one-off import outside `pull`), or the JSON
-produced by the free-plan escape hatch below — the Figma Plugin API can
-read local variables on **any** plan, run from Figma's own developer
-console. `figmog vars` prefers an authoritative record (auto-synced or
-imported) over inference whenever one exists. Unlike auto-synced records,
-manually imported ones are **not** swept by a later pull that has no
-Enterprise export of its own (e.g. on a non-Enterprise plan) — they
-persist until re-imported or `pull --fresh`.
-
-```js
-// Figma → Plugins → Development → Open console, then paste:
-(async () => {
-  const collections = await figma.variables.getLocalVariableCollectionsAsync();
-  const variables = await figma.variables.getLocalVariablesAsync();
-  const out = { variables: {}, variableCollections: {} };
-  for (const c of collections)
-    out.variableCollections[c.id] = { id: c.id, name: c.name, modes: c.modes, defaultModeId: c.defaultModeId };
-  for (const v of variables)
-    out.variables[v.id] = { id: v.id, name: v.name, resolvedType: v.resolvedType,
-                            variableCollectionId: v.variableCollectionId,
-                            valuesByMode: v.valuesByMode, description: v.description, scopes: v.scopes };
-  console.log(JSON.stringify(out));
-})();
-// save the logged JSON, then: figmog import-variables vars.json
-```
-
-A third source, for paid Dev/Full seats: `figmog serve`'s cached proxy
-(see "Use from agents (MCP)" above) forwards `get_variable_defs` to
-Figma's desktop server like any other native-named tool, selection-scoped
-and cached by file version like the rest of the proxy. It's still
-selection-scoped rather than whole-collection, so `import-variables`
-remains the way to get an authoritative, whole-collection record into the
-mirror; anyone with a paid seat can pipe a proxied `get_variable_defs`
-call's output into it by hand. Figma's *remote* MCP server (as opposed to
-the local desktop one figmog proxies) caps Starter users at 6 tool calls
-a *month* and isn't something figmog talks to at all.
-
-## Manual live check
-
-Not run in CI (needs a real `FIGMA_TOKEN` and a real file); this is how to
-verify it by hand:
+### 2. Set a Figma token
 
 ```console
 $ export FIGMA_TOKEN=figd_…
-$ figmog pull <figma url>
-$ figmog status
-$ figmog components
-$ figmog search "pricing card"
-$ figmog vars
 ```
 
-`pull` pays the one Tier-1 fetch and prints a churn summary. Every command
-after it — `status`, `components`, `search`, `vars` — is a local read:
-acceptance is that they return in milliseconds, regardless of how large
-the mirrored file is.
+Make one at figma.com under settings, security, personal access tokens.
+
+### 3. Connect it to Claude Code
+
+```console
+$ claude mcp add figmog -- $PWD/figmog serve
+```
+
+### 3b. Remove the official Figma MCP server, if you have one connected
+
+```console
+$ claude mcp list        # find its name; it is usually `figma`
+$ claude mcp remove figma
+```
+
+Run one or the other, not both. figmog already forwards the official
+server's tools, with caching, whenever the Figma desktop app is running, so
+dropping the direct connection loses nothing. Keep both and the agent sees
+two overlapping Figma servers, then picks tools badly.
+
+### 4. Ask for something
+
+> Using figmog, pull this file: [figma file URL], then build this frame in
+> HTML & CSS: [figma frame URL]
+
+figmog mirrors the file the first time the agent references it, and every
+read after that answers from local storage. Frame URLs carry `?node-id=…`,
+which figmog's tools accept directly, so paste the URL straight out of
+Figma.
+
+## The CLI, for humans
+
+```console
+$ figmog pull "https://www.figma.com/design/<key>/<name>"
+$ figmog search "pricing card"
+$ figmog dump 1:23 --fields id,name,type,fills --depth 3
+$ figmog serve                     # the MCP server, in another terminal
+```
+
+The first `pull` writes the file key to `.figmog/current`, so later commands
+can drop the file argument. Read commands never touch the network and print
+JSON on stdout; failures print `{"error": ...}` on stderr and exit 1. Every
+command is documented in [`docs/SPEC.md`](docs/SPEC.md) §10.
+
+## figmog against the API
+
+| | figmog | Figma REST API and MCP |
+|---|---|---|
+| node read, p50 | 0.055ms | 972.6ms |
+| sustained rate | 149 req/s | ~10 file requests/min on the free plan |
+| second read of the same node | free | spends the budget again |
+| counts, pointer matches, every text node | one local scan | no endpoint offers them |
+| re-sync of an unedited file | 4.6ms, zero churn | one Tier-1 fetch |
+
+Three things spend Figma's budget: a pull (`figmog pull`, the poll loop's own
+sync, `figmog_sync`, `figmog_open`), an explicit `figmog images` fetch, and a
+proxied call that reaches the desktop app. Every `figmog_*` read tool is
+free.
+
+## What the mirror gives an agent
+
+### Reads work while the server runs
+
+`figmog serve` owns the store, and it listens on a unix socket at
+`.figmog/serve.sock`. Read commands, `figmog tools` and `figmog call` connect
+there first and answer from the running server's live view; with no server
+listening they open the store directly. `--no-socket` forces direct mode on
+both sides. `pull` is a writer and always opens the store itself, so while a
+server runs its error points at `figmog call figmog_sync`, which reaches the
+process that owns the store. See `docs/SPEC.md` §6 and §10.
+
+### One process, many files
+
+`figmog serve [FILE]...` takes zero or more file URLs or keys. Every
+`figmog_*` tool has an optional `file` argument, and a file referenced for
+the first time gets mirrored then (one Tier-1 pull). Starting with zero files
+needs no token up front. `figmog_open` and `figmog_files` manage the set. See
+`docs/SPEC.md` §6.
+
+### Reads shaped for building
+
+`figmog dump <id>` returns a node and its descendants as nested raw JSON,
+with `--depth N` and `--fields a,b,c` to keep the payload small.
+`--under <id>` scopes `text`, `find`, `search` and `where` to one subtree,
+and composes with `--page`. `--resolve-vars` annotates every
+`boundVariables` binding site with the variable's name and per-mode values
+under a `resolved_variables` key, so a generator can emit
+`var(--color-bg-primary)` instead of a literal. Node arguments accept a bare
+id, a `12-34` id, or a pasted Figma URL. See `docs/SPEC.md` §12 and §13.
+
+### Vector geometry
+
+`figmog pull --geometry` asks Figma for `fillGeometry` and `strokeGeometry`
+path data, so vector nodes carry their outlines in `raw`. The flag is stored
+per mirror, so watch ticks, `figmog_sync` and auto-opens keep requesting
+geometry and the records never churn from flag drift. `pull --fresh` turns it
+back off. See `docs/SPEC.md` §14.
+
+### Image bytes
+
+`figmog images <node-id>...` downloads node renders plus the image fills
+those nodes reference, writes them to `--out` (default `./figmog-images/`),
+and prints a manifest. Bytes are cached against the file version, so asking
+again for an unedited file spends nothing. Nothing in figmog fetches images
+on its own, because Figma's images endpoints are its most rate-limited. See
+`docs/SPEC.md` §15.
+
+### Freshness is polling, not push
+
+`figmog serve` polls the cheap Tier-3 meta endpoint every `--interval`
+seconds (default 10) and spends a Tier-1 file fetch only when the file's
+watermark moves. A change shows up within one interval. Figma's `FILE_UPDATE`
+webhook is Enterprise-only and debounced up to 30 minutes, so polling a cheap
+endpoint beats waiting for it.
+
+### Variables on any plan
+
+On Enterprise, every pull also fetches `variables/local` and folds those
+records in. Elsewhere figmog inverts the `boundVariables` references Figma
+bakes into the file JSON, which covers each variable's default-mode value.
+`figmog import-variables <export.json>` takes a full-fidelity export from
+Figma's plugin console on any plan. See `docs/SPEC.md` §9.
+
+### The tools
+
+`figmog serve` exposes 21 `figmog_*` tools: 17 reads of the local mirror,
+`figmog_sync`, `figmog_images`, and the two mirror-management tools. Unless
+`--no-upstream`, it also proxies Figma's desktop Dev Mode MCP server (paid
+Dev or Full seat, desktop app running), merging those tools into the same
+list and caching `get_*`/`list_*` responses by file version. Every name and
+argument shape is in `docs/SPEC.md` §6 and §8. `figmog tools` prints the
+merged list, and `figmog call <tool>` invokes any of them from a shell.
+
+## The benchmark run
+
+<details>
+<summary>Per-tool numbers, sync phase, and provenance</summary>
+
+Measured 2026-08-17 on Apple Silicon against a real 5,339-node production
+file.
+
+| tool | p50 (ms) |
+|---|---|
+| `figmog_node` | 0.055 |
+| `figmog_search` | 0.067 |
+| `figmog_instances` | 0.11 |
+| `figmog_tree` | 0.46 |
+| `figmog_stats` | 16.9 |
+| `figmog_where` | 22.1 |
+
+Sync phase: re-syncing the unchanged file took 4.6ms and produced zero
+churn. Load phase: 5,000 tool calls in 33.6s, 149 requests a second. The same
+5,000 reads at Figma's Tier-1 budget of ~10 requests a minute would take
+around 500 minutes. The API comparison figure (972.6ms p50) comes from 5 live
+API calls against the same file during the run.
+
+Only the p50 column was kept from that run, so the p95, p99 and max columns
+the harness also prints are absent here.
+
+The harness itself was retired from the binary in v0.0.1's slim-down and
+lives in the repo history: `docs/history/2026-08-16-figmog-bench.md`.
+
+</details>
+
+## Install
+
+Download `figmog-<version>-<target>.tar.gz` and `SHA256SUMS` from
+[Releases](https://github.com/sanctuarycomputer/figmog/releases). Targets:
+`aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`.
+
+```console
+$ shasum -a 256 -c SHA256SUMS --ignore-missing   # sha256sum on Linux
+$ tar xzf figmog-<version>-<target>.tar.gz
+$ chmod +x figmog
+$ xattr -d com.apple.quarantine ./figmog         # macOS: builds are unsigned
+$ ./figmog --help
+```
+
+The checksum line should print `figmog-<version>-<target>.tar.gz: OK`. The
+macOS builds are not signed or notarized, so Gatekeeper refuses to run them
+until the quarantine attribute is cleared once. The Linux build is compiled
+on Ubuntu 24.04 and needs glibc 2.39 or newer; on an older distribution,
+build from source:
+
+```console
+$ git clone https://github.com/sanctuarycomputer/figmog.git
+$ cd figmog && cargo build --release
+```
+
+That needs a Rust toolchain and network access, since the build fetches
+`fold` from its pinned git rev.
 
 ## Limitations
 
-- **Variables are plan-gated** — on non-Enterprise plans (no automatic
-  `variables/local` sync), inference (always on) covers each variable's
-  default-mode value; a non-default mode's value is visible only where a
-  frame explicitly overrides that mode. Full per-mode fidelity requires
-  either the Enterprise auto-sync or a manual `import-variables`.
-- **The desktop proxy needs the Figma app open on the right file** — the
-  desktop MCP server has no concept of "which file"; every proxied
-  (non-`figmog_*`) tool call answers for whatever file is currently open
-  in the Figma desktop app, independent of any mirror `figmog serve`
-  manages, and a `file` argument sent on such a call is silently ignored.
-- **Freshness is polling, not push** — `figmog serve`'s poll loop polls
-  the cheap `last_touched_at` metadata field on an interval; a change can
-  take up to `--interval` seconds to be reflected, and Figma's
-  `FILE_UPDATE` webhook (unavailable on the free plan, debounced up to 30
-  minutes even where it exists) isn't used.
-- **Single-writer store** — fjall allows only one open handle per store.
-  `figmog serve` holds an exclusive lock on its `--db` for its whole
-  life; a CLI command against the same store while `serve` is running
-  fails fast with a clean `store is locked` error (exit 1), not a raw
-  panic — drive the running server through its own MCP tool calls
-  instead, or stop `serve` first.
-- **No image renders** — figmog mirrors document structure and properties,
-  not rendered pixels; there's no `GET /v1/images` integration.
-- **Style definitions are derived, not authoritative** — the file JSON's
-  `styles` map is metadata only (id, name, type), not the style's actual
-  properties. `figmog styles --values` derives a definition from one
-  consumer node's resolved properties (e.g. a text style's `TypeStyle`
-  from a TEXT node that uses it) — if a style currently has no consumers,
-  it has no derivable value.
-- **Instance overrides beyond the serialized subtree are not resolved** —
-  Figma serializes an INSTANCE's overridden children as ordinary nodes
-  under it, and those mirror like any other node, but overrides that
-  Figma doesn't materialize into the subtree are not reconstructed.
-- **`pull --fresh` wipes imported variables** — `--fresh` deletes the whole
-  store, including `import-variables` records that normally survive
-  ordinary pulls (they're exempt from the file-sync sweep, not from a full
-  wipe). On an Enterprise plan the very next `pull` repopulates them
-  automatically (auto-sync); everywhere else, re-run `import-variables`
-  after a `--fresh` pull if you need authoritative variable data back.
+- Full per-mode variable values need either an Enterprise plan or a manual
+  `import-variables`; inference alone covers the default mode.
+- The proxied desktop tools answer for whatever file is open in the Figma
+  app. They have no concept of "which file", so a `file` argument on such a
+  call is ignored.
+- A file change is visible within one poll interval, not instantly.
+- `figmog images` spends Figma's most rate-limited endpoints and is never
+  called automatically. Cached bytes are keyed to the file version and are
+  dropped when the version moves.
+- Style definitions are derived from one consumer node, since the file JSON
+  carries style metadata only. A style with no consumers has no derivable
+  value.
+- Instance overrides that Figma does not serialize into the instance's
+  subtree are not reconstructed.
+- `pull --fresh` wipes the whole store, including imported variables and the
+  stored geometry flag.
+- macOS and Linux only. The control plane is a unix domain socket and the
+  code uses unix filesystem APIs directly, so there is no Windows build.
+- One process may open a store at a time (fjall is single-writer).
+  `figmog serve` holds that handle for its life. Other commands reach it over
+  the socket instead, but `--no-socket`, or a `--db` naming the store `serve`
+  owns, still gets the plain `store is locked` error.
+
+## License
+
+figmog is licensed under AGPL-3.0-only. The full text is in
+[`LICENSE`](LICENSE). The v0.0.1 release stays MIT, for that snapshot only.
+If you want figmog under other terms, email hello@sanctuary.computer and we
+will talk.
+
+figmog depends on [`fold`](https://github.com/flowercomputers/bogkit) through
+a pinned git dependency, and upstream `bogkit` currently ships with no
+license file. Building and running figmog from source is fine. Publishing
+binaries that embed `fold` more widely than this repo's own testing releases
+waits on upstream adding a license, which is a separate decision from
+figmog's own license.
+
+## A note for Figma
+
+You already ship a local MCP server for design agents. Shouldn't it work like
+this, answering from the machine the file is already on, with no rate limit
+between an agent and a design it is allowed to read?
+
+If you would like to use this code, we would love to give it to you. Email us
+at hello@sanctuary.computer.

--- a/README.md
+++ b/README.md
@@ -167,26 +167,26 @@ merged list, and `figmog call <tool>` invokes any of them from a shell.
 <details>
 <summary>Per-tool numbers, sync phase, and provenance</summary>
 
-Measured 2026-08-17 on Apple Silicon against a real 5,339-node production
-file.
+Measured 2026-08-17 on Apple Silicon against a real production file: 5,339
+nodes, 5,921,203 bytes, fetched in 4,662.2ms.
 
-| tool | p50 (ms) |
-|---|---|
-| `figmog_node` | 0.055 |
-| `figmog_search` | 0.067 |
-| `figmog_instances` | 0.11 |
-| `figmog_tree` | 0.46 |
-| `figmog_stats` | 16.9 |
-| `figmog_where` | 22.1 |
+Cold sync: 146.0ms flatten plus 81.3ms sync for 5,394 records, 66,364
+records a second. Re-pull of the unchanged file: 4.6ms, churn zero.
 
-Sync phase: re-syncing the unchanged file took 4.6ms and produced zero
-churn. Load phase: 5,000 tool calls in 33.6s, 149 requests a second. The same
-5,000 reads at Figma's Tier-1 budget of ~10 requests a minute would take
-around 500 minutes. The API comparison figure (972.6ms p50) comes from 5 live
-API calls against the same file during the run.
+| tool | calls | p50 (ms) | p95 | p99 | max |
+|---|---|---|---|---|---|
+| `figmog_node` | 834 | 0.055 | 0.069 | 0.082 | 1.482 |
+| `figmog_search` | 834 | 0.067 | 0.124 | 0.191 | 0.621 |
+| `figmog_instances` | 833 | 0.111 | 0.125 | 0.151 | 0.607 |
+| `figmog_tree` | 833 | 0.462 | 0.529 | 0.733 | 2.172 |
+| `figmog_stats` | 833 | 16.892 | 18.587 | 22.385 | 38.561 |
+| `figmog_where` | 833 | 22.057 | 23.686 | 27.551 | 40.437 |
 
-Only the p50 column was kept from that run, so the p95, p99 and max columns
-the harness also prints are absent here.
+Load phase: 5,000 queries in 33.6s, 149 requests a second. API comparison: 5
+live calls against the same file, p50 972.6ms, max 1,189.1ms. `figmog_node`
+at 0.055ms against the `/nodes` p50 of 972.6ms is the 17,657x figure. At
+Figma's Tier-1 budget of ~10 requests a minute, those 5,000 calls take about
+500 minutes.
 
 The harness itself was retired from the binary in v0.0.1's slim-down and
 lives in the repo history: `docs/history/2026-08-16-figmog-bench.md`.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -17,7 +17,12 @@ queries — answers from local storage in milliseconds, at zero Figma API
 cost. `figmog serve` runs the same engine as a long-lived MCP stdio
 server with its own poll loop, plus a cached proxy to Figma's native
 desktop Dev Mode MCP server, so it can be the *only* Figma MCP an agent
-needs to connect.
+needs to connect. `serve` additionally listens on a unix-socket control
+plane (§6a), so CLI reads answer from the running server instead of
+failing on the store lock it holds.
+
+Two commands spend Figma's API budget deliberately and explicitly: `pull`
+(and the pull paths `serve` drives) and `figmog images` (§15).
 
 ## 2. Architecture
 
@@ -38,7 +43,7 @@ needs to connect.
                          │  store.rs                │  figmog_pipeline! (fold)
                          │  sync() — upsert + sweep │  KeyedStream<Id, Rec, _>
                          └────────────┬─────────────┘
-                                      │ 8 materialized sinks (frozen names)
+                                      │ 16 materialized sinks (frozen names)
                                       ▼
                          ┌─────────────────────────┐
                          │  query.rs                 │  one source of truth for
@@ -49,10 +54,10 @@ needs to connect.
                     ▼                                    ▼
          ┌─────────────────────┐              ┌─────────────────────────┐
          │  cli/ (read.rs)      │              │  dispatch.rs              │
-         │  pretty-JSON on      │              │  dispatch_read_tool +      │
-         │  stdout               │              │  tool_registry (19 tools)  │
-         └─────────────────────┘              └────────────┬────────────┘
-                                                              │
+         │  pretty-JSON stdout, │              │  dispatch_read_tool +      │
+         │  or a socket client  │              │  tool_registry (21 tools)  │
+         │  of serve (§6a)      │              └────────────┬────────────┘
+         └─────────────────────┘                           │
                                                               ▼
                                               ┌─────────────────────────┐
                                               │  serve.rs / sessions.rs   │
@@ -82,12 +87,18 @@ matching [`Rec`](../src/model.rs) variant:
 | `VariableCollection(String)` | `VariableCollectionRec` | same as above |
 | `Meta` | `FileMeta` | one row: name, version, last_modified, synced_at_unix_ms |
 | `ProxyCache(String)` | `ProxyCacheRec` | cached proxied-tool responses (§8) |
+| `MirrorConfig` | `MirrorConfigRec` | one row: this mirror's sticky pull settings (§14) |
+| `ImageBlob(String)` | `ImageBlobRec` | cached render and fill bytes (§15) |
 
 `Id`/`Rec` are **append-only enums** — postcard encodes variant indices
 positionally, so inserting a new variant anywhere but the end would
-silently corrupt every existing on-disk store. `ProxyCache` is the most
-recent addition and sits last in both enums; the next new record kind
-goes after it, never between existing variants.
+silently corrupt every existing on-disk store. `ImageBlob` is the most
+recent addition and sits last in both enums (`MirrorConfig` immediately
+before it); the next new record kind goes after `ImageBlob`, never
+between existing variants. The same rule is why a new setting arrives as
+a new record kind rather than a new field on an existing `Rec` struct:
+struct fields are positional too, so widening `FileMeta` would break
+every store already on disk, while appending `MirrorConfig` does not.
 
 `NodeRec` is the workhorse record: id, parent/child-index, page id
 (nearest CANVAS ancestor), type, name, visibility, TEXT `characters`,
@@ -105,6 +116,18 @@ upstream result). A hit requires `tool`/`args_canonical` to match the
 collidable, and tool arguments are agent-authored strings, so the key
 hash alone is not trusted (see `cache::lookup`).
 
+`MirrorConfigRec` (§14): `geometry: bool`, one row per mirror. An absent
+row means `false`, which is what every store written before this record
+kind existed reports.
+
+`ImageBlobRec` (§15): `key_hash` (= the `Id::ImageBlob` key), `kind`
+(`"render"` or `"fill"`), `subject` (node id for a render, `imageRef`
+hash for a fill), `format`, `scale_milli` (requested scale × 1000, always
+`1000` for fills), `file_version`, and `bytes`. A hit checks
+`kind`/`subject`/`format`/`scale_milli` against the request rather than
+trusting the key hash, the same identity check `cache::lookup` makes for
+proxied responses.
+
 **Determinism contract:** every map-shaped field is a sorted `Vec` of
 pairs; every canonical-JSON string comes from `serde_json` without
 `preserve_order` (`serde_json::Value` is `BTreeMap`-backed here, so
@@ -115,7 +138,7 @@ detector. No `HashMap` iteration ever reaches an output boundary.
 
 ## 4. Pipeline and sinks
 
-`store::figmog_pipeline!()` wires the flattened records into 14
+`store::figmog_pipeline!()` wires the flattened records into 16
 `fold` terminal sinks, keyed off `store.rs`'s pure branch functions
 (`node_only`, `child_edge`, `text_doc`, `instance_edge`, `style_edges`,
 `variable_edges`, `type_edge`, plus one `rec_branch!`-generated filter per
@@ -138,6 +161,13 @@ is a breaking store-format change:
 | `variable_collections` | Table | collection id | `vars` |
 | `meta` | Table | `0u8` (not `()` — postcard-encodes to zero bytes, and the store forbids empty keys) | `status`, version comparisons |
 | `proxy_cache` | Table | cache key hash | proxied-tool caching (§8) |
+| `mirror_config` | Table | `0u8` (one row, like `meta`) | sticky pull settings (§14) |
+| `images` | Table | image cache key hash | render/fill byte caching (§15) |
+
+`mirror_config` and `images` are appended at the pipeline root's tail, so
+the reader tuple grows at the end and older stores keep decoding. Both
+sit outside `collect_sweepable` (§5): a file sync never removes a config
+row, and image rows are evicted by version instead.
 
 `bound_to`'s edges are deliberately not deduped before feeding the
 inverted index: `InvertedIndex` is set-semantic, so duplicate `(node,
@@ -167,13 +197,14 @@ whole pipeline — `unchanged` increments, no index writes happen. A
 spurious watch trigger or a repeated `pull` therefore costs exactly one
 Tier-1 fetch and nothing else downstream.
 
-**Proxy-cache eviction** is a separate pass, not folded into `sync`'s
-sweep (its churn accounting stays untouched by this feature): after a
-sync whose file *version* actually moved, every `proxy_cache` row tagged
-with the old version is identified (`store::stale_cache_ids`) and removed
-(`store::evict_stale_cache`). This runs after every `pull`/`figmog_sync`/
-watch-tick pull that changes the version, and is bundled into `pull
---fresh`'s whole-store wipe too.
+**Version-keyed cache eviction** is a separate pass, not folded into
+`sync`'s sweep (its churn accounting stays untouched by this feature):
+after a sync whose file *version* actually moved, every `proxy_cache` row
+(`store::stale_cache_ids`) and every `images` row
+(`store::stale_image_ids`) tagged with the old version is removed through
+the one `store::evict_stale_cache` function. This runs after every
+`pull`/`figmog_sync`/watch-tick pull that changes the version, and is
+bundled into `pull --fresh`'s whole-store wipe too.
 
 ## 6. `figmog serve`: multi-file sessions, watch, MCP
 
@@ -228,18 +259,25 @@ to the default (see "Startup" above). There is no idle-session eviction
 and no cross-file queries — once opened, a session stays open for the
 process's life.
 
-**The 19 `figmog_*` tools** (`dispatch::tool_registry`): 12 core reads
+**The 21 `figmog_*` tools** (`dispatch::tool_registry`): 13 core reads
 (`figmog_status`, `figmog_pages`, `figmog_tree`, `figmog_node`,
-`figmog_find`, `figmog_search`, `figmog_instances`, `figmog_components`,
-`figmog_styles`, `figmog_uses`, `figmog_vars`, `figmog_sync`) + 5
-whole-file structural queries (`figmog_stats`, `figmog_path`,
-`figmog_text`, `figmog_where`, `figmog_at`) + 2 multi-file management
-tools that aren't per-file (`figmog_open`, `figmog_files`). Every tool but
-`figmog_sync`/`figmog_open` reads the local mirror at zero Figma API
-cost; `figmog_sync` forces one pull and is the only local tool that
-spends Figma's rate budget. `figmog_status`'s result also carries
+`figmog_subtree`, `figmog_find`, `figmog_search`, `figmog_instances`,
+`figmog_components`, `figmog_styles`, `figmog_uses`, `figmog_vars`,
+`figmog_sync`) + 5 whole-file structural queries (`figmog_stats`,
+`figmog_path`, `figmog_text`, `figmog_where`, `figmog_at`) +
+`figmog_images` (§15) + 2 multi-file management tools that aren't
+per-file (`figmog_open`, `figmog_files`). Every tool but
+`figmog_sync`/`figmog_open`/`figmog_images` reads the local mirror at
+zero Figma API cost; `figmog_sync` forces one pull, `figmog_open` pulls a
+newly referenced file, and `figmog_images` fetches renders and fills, so
+those three are the local tools that spend Figma's rate budget.
+`figmog_status`'s result also carries
 `upstream: "connected" | "unreachable" | "disabled"`, spliced in at the
 call site that knows it (never inside `query::status` itself).
+`figmog_open` also takes an optional `geometry` boolean (§14).
+
+The 19 per-file tools each carry the optional `file` property described
+above; `figmog_open` and `figmog_files` don't.
 
 **Protocol (`mcp.rs`):** pure JSON-RPC 2.0 over stdio frames, no store,
 no I/O. `initialize` echoes the client's `protocolVersion` (or
@@ -251,6 +289,32 @@ results are wrapped as a single text content block
 (`ToolOutput::Raw`) since they're already a complete, correctly-shaped
 MCP `CallToolResult` (re-wrapping would double-encode a non-text content
 type like `get_screenshot`'s image block).
+
+## 6a. The unix-socket control plane
+
+`figmog serve` binds `<figmog-root>/serve.sock` (mode 0600, inside a root
+tightened to 0700) before it opens any session store, and unlinks it on
+exit through a guard held for `run_serve`'s whole scope. A pre-existing
+socket file is probed with a connect first (`serve::classify_probe`):
+connect succeeds ⇒ another `serve` owns this root, and this process exits
+with the standard `{"error": ...}` JSON; any connect failure ⇒ the file
+is stale, so it is unlinked and rebound. `--no-socket` skips binding.
+
+Frames on the socket are the same newline-delimited JSON-RPC the stdio
+loop reads. `initialize` is optional for socket clients: `tools/call` is
+accepted directly, since `mcp::handle_message` treats every frame
+independently. An acceptor thread gives each connection its own reader
+thread, which tags frames with a connection id and forwards them into the
+same `mpsc` channel stdin feeds; the connection's write half is
+registered before its reader starts, so a response always has somewhere
+to route. Responses are written to the owning connection under a write
+timeout, so a client that stops reading is disconnected and dropped from
+the registry rather than stalling the single-threaded loop; a vanished
+client is a silent no-op. The store stays single-threaded throughout:
+socket traffic interleaves with MCP frames and watch ticks like any other
+request.
+
+The CLI side of the plane is in §10.
 
 ## 7. Style values: derived, not authoritative
 
@@ -268,7 +332,7 @@ tools`/`figmog call`, §10) probes Figma's native desktop app's Dev Mode
 MCP server (`http://127.0.0.1:3845/mcp` by default, streamable HTTP) at
 startup. This requires a **paid Dev/Full seat** and the desktop app
 running with Dev Mode MCP enabled. On success, `tools/list` merges
-figmog's 19 local tools with every upstream tool verbatim (description
+figmog's 21 local tools with every upstream tool verbatim (description
 prefixed `"[via Figma desktop] "`); on failure, one stderr line and
 local-only tools for the rest of the process — **no mid-session
 re-probe**, so a server that starts before the desktop app is reachable
@@ -359,21 +423,47 @@ or a broken-pipe message.
 The CLI is split by concern: `src/cli/mod.rs` (clap types, top-level
 dispatch, `run`, the shared store-opening/JSON-writing helpers),
 `src/cli/pull.rs` (`pull`, the typed `PullError`, `.figmog/current`),
-`src/cli/read.rs` (the 16 read-only query commands), `src/cli/call.rs`
+`src/cli/read.rs` (the 17 read-only query commands), `src/cli/call.rs`
 (`tools`, `call`, `import-variables` — the cached-proxy CLI parity
 surface, so every tool `figmog serve` would expose is reachable without
-an MCP client).
+an MCP client), `src/cli/images.rs` (`images`, §15), and
+`src/cli/socket.rs` (the client half of the control plane, §6a).
 
 `figmog tools` never opens the store (it only needs an optional upstream
 probe), so unlike every other command it does **not** require a resolved
 mirror — no established `.figmog/current` and no `--db` needed. `figmog
 call` does need one, since local tool dispatch reads the store.
 
+**Socket-first routing (§6a).** When neither `--no-socket` nor `--db` is
+given, every read command, plus `tools`, `call` and `images`, first tries
+`<.figmog>/serve.sock`. Reachable ⇒ the command becomes a client of the
+running `serve`: `cli::cmd_as_tool_call` maps the subcommand to the tool
+name and argument object `dispatch::dispatch_read_tool` expects, so the
+JSON on stdout is byte-identical to the direct-open answer, and a
+serve-side failure surfaces as the standard `{"error": ...}` exit 1.
+Unreachable ⇒ the store is opened directly. `--db` bypasses the socket
+entirely, since it names a store rather than a root. Null-valued optional
+arguments are stripped from a mapped command's arguments, so an omitted
+flag stays omitted rather than arriving as an explicit `null` (`figmog
+call`'s own `--args` payload is passed through untouched). A routed
+command also carries the mirror `.figmog/current` resolves to as its
+`file` argument, so it answers for the same file the direct path would;
+`figmog call figmog_open` is the exception, since there `file` names the
+file to open rather than a routing target. A routed `figmog_status`
+result drops the `upstream` field serve splices in, keeping the CLI's
+output byte-identical on both paths.
+
+`pull` is a writer and always opens the store directly. While `serve`
+holds that store, `pull`'s lock error additionally says "or ask the
+running serve: figmog call figmog_sync", which reaches the process that
+owns it.
+
 **Single-writer constraint:** fjall allows only one open handle per
-store. `figmog serve` holds its `--db`'s lock for its whole life; any CLI
-command that tries to open the same store while `serve` runs gets a
-clean `store is locked — is figmog serve running? ...` error (exit 1),
-never fold's raw lock panic (exit 101) — see `open_store_checked`.
+store. `figmog serve` holds its `--db`'s lock for its whole life; a CLI
+command that opens the same store directly (`--no-socket`, an explicit
+`--db`, or `pull`) while `serve` runs gets a clean `store is locked — is
+figmog serve running? ...` error (exit 1), never fold's raw lock panic
+(exit 101) — see `open_store_checked`.
 
 ## 11. Determinism and schema-stability contracts
 
@@ -387,8 +477,131 @@ never fold's raw lock panic (exit 101) — see `open_store_checked`.
 - `Id`/`Rec` are append-only postcard enums (§3) — a store built by an
   older figmog binary must still open cleanly with a newer one, as long
   as no variant was reordered or removed.
+- `Rec` payload structs are positional too, so new stored state arrives
+  as a new record kind rather than a new field on an existing struct
+  (§3, §14).
 - Sink names (§4) are frozen on-disk schema; renaming one changes what
-  store directory an unmodified binary can open.
+  store directory an unmodified binary can open. New sinks are appended
+  at the pipeline root's tail, so reader tuples grow at the end.
 - `fold`/`bogkit` is upstream: never vendored, never patched — figmog
   consumes only the pinned git dependency's public API (see the crate's
   `CLAUDE.md`).
+
+## 12. Node addressing
+
+`ident::parse_node_ref(input) -> Option<(Option<file_key>, node_id)>` is
+the one place a node-id argument is parsed. A bare id passes through with
+`normalize_node_id`'s `0-1` ⇒ `0:1` rule and nothing else. A figma.com
+URL carrying `node-id=` anywhere in its query yields that id
+(percent-decoded, normalized) plus the URL's file key when the URL names
+one; a figma.com URL with no `node-id=` yields `None` rather than being
+treated as an id. `ident::normalize_node_ref` is the "just give me the
+id" wrapper the query layer calls, falling back to the raw input.
+
+Every node-id-shaped argument accepts both forms: the CLI's `id`,
+`target`, `--under` and `--page` arguments, and the tools' `id`, `under`,
+`target` and `page` properties. In `serve`, when a tool call omits `file`
+and one of `id`/`under`/`target` is a URL that names a file,
+`dispatch::infer_file_from_node_ref` routes the call at that file and
+auto-opens it. An explicit `file` always wins; a disagreement between the
+two is named in the error text if the node isn't found, comparing
+normalized keys so two spellings of the same file don't false-positive.
+
+## 13. Subtree dump, subtree scoping, resolved variables
+
+**Subtree dump** (`query::subtree`; `figmog dump <id>`,
+`figmog_subtree`): the node's full `raw` JSON with `children` nested
+recursively in child-index order, to `depth` levels (unlimited when
+omitted). `fields` projects every node to the named raw fields; `id`,
+`name` and `type` survive projection by an explicit keep-list, and
+`children` plus `resolved_variables` are inserted after projection runs,
+so they survive too. An unknown field name is simply absent. Response
+size is the caller's business: the tool description says so and points at
+`depth`/`fields`.
+
+**Subtree scoping** (`query::resolve_under` + `query::scope_ids`;
+`--under <id>` on `text`/`find`/`search`/`where` and the matching tool
+argument): one BFS over the `children` index from the scope root
+(inclusive, cycle-safe via a visited set) collects the descendant id set,
+and results are filtered against it. It composes with `page` by
+intersection. An unknown scope id gives the standard `no node ...` error.
+`search` ranks the whole corpus before truncating when a scope is active,
+so an in-scope hit can't be lost to an out-of-scope one taking its slot
+in the top-N.
+
+**Resolved variables** (`query::resolved_variables`; `--resolve-vars` on
+`get`, `dump` and `styles --values`, plus the matching tool arguments): a
+read-time join that emits a `resolved_variables` array alongside the raw
+data, never mutating it. Each entry is `{pointer, variable_id,
+variable_name, values_by_mode}` when the variables table has that id
+(mode ids mapped to mode names through the collection), or `{pointer,
+variable_id, source: "unresolved"}` when it doesn't. The flag never
+errors; it resolves what it can. On `styles --values`, the annotation
+covers bindings whose pointer falls under that style type's raw-JSON
+prefix (FILL ⇒ `/fills`, and so on).
+
+## 14. Vector geometry and mirror config
+
+`pull --geometry` adds `?geometry=paths` to the Tier-1 file fetch
+(`api::file_url`), so vector nodes carry `fillGeometry` and
+`strokeGeometry` in their `raw`.
+
+The flag is stored per mirror as the single `Rec::MirrorConfig` row (§3,
+§4) rather than as a new field on `FileMeta`, because postcard struct
+fields are positional: widening an existing `Rec` struct breaks every
+store already on disk, while appending an enum variant does not.
+
+`store::effective_geometry(flag, stored)` is `flag || stored`, so every
+later pull of that mirror keeps requesting geometry: the watch tick,
+`figmog_sync`, `figmog_open` and an auto-open inside `resolve` all read
+the stored flag first, and the records never churn from flag drift. The
+way back off is `pull --fresh`, whose callers pass `stored = false`
+without reading the store they are about to wipe. `figmog_open` takes an
+optional `geometry` argument; omitting it preserves whatever the mirror
+already has. The config row is written in its own write transaction,
+outside `sync`'s, and is never swept.
+
+## 15. Images
+
+`figmog images <node-id>... [--format png|svg] [--scale N] [--out <dir>]`
+and the `figmog_images { ids, format?, scale?, file? }` tool fetch image
+bytes. Nothing in figmog calls them on its own: the images endpoints are
+Figma's most rate-limited, so a fetch happens only when a person or an
+agent asks for one.
+
+**Two fetch kinds behind one command.** Renders come from `GET
+/v1/images/:key?ids=…&format=…&scale=…`, which returns per-node URLs that
+are then downloaded. Fills come from the `fills` of the requested nodes:
+every `imageRef` hash found there is resolved through `GET
+/v1/files/:key/images` (fetched at most once per invocation) and
+downloaded. One invocation makes at most one call of each kind.
+
+**Cache.** Bytes land in `images` as `Rec::ImageBlob` rows keyed by a
+hash of kind, subject, format and scale (§3). A hit requires the stored
+row's identity fields to match the request and its `file_version` to
+equal the mirror's current version, so a repeat request against an
+unedited file spends nothing. Rows tagged with an older version are
+evicted by the same version-change pass that evicts `proxy_cache` (§5).
+
+**Output.** The CLI writes each item into `--out` (default
+`./figmog-images/`) and prints a manifest of
+`[{id|ref, kind, format, bytes, cached, path?, error?}]`, where `bytes`
+is a count. Exit is 0 when at least one item was written, 1 otherwise,
+and the manifest is the stdout payload either way. The MCP tool returns
+the same manifest plus, per item within the 1 MiB inline cap: an `image`
+content block (base64) for raster formats, or a `text` block carrying the
+raw markup for `format=svg`. SVG ships as text because agents consume the
+markup directly and clients render `image/svg+xml` blocks inconsistently.
+The cap is measured on the *encoded* length, since base64 inflates raw
+bytes by about a third; an item over the cap becomes a text entry naming
+the `figmog images --out` command that downloads it.
+
+**Rate limits.** A 429 is recorded per item in the manifest (an `error`
+field carrying the Retry-After) and the rest of the results still come
+back: exit 0 if at least one item succeeded, else 1.
+
+**Routing.** `figmog images` both spends API budget and writes cache
+rows, so unlike a read command it cannot open a store `serve` holds. With
+the socket reachable it routes through serve's own `figmog_images` tool
+(serve owns the caching); with `--no-socket` or no server listening it
+fetches and writes directly, like `pull`.

--- a/docs/plans/2026-08-17-v0.0.2.md
+++ b/docs/plans/2026-08-17-v0.0.2.md
@@ -1,0 +1,33 @@
+# v0.0.2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans.
+
+**Goal:** Ship spec `docs/specs/2026-08-17-v0.0.2-ergonomics.md` — all six ergonomic features + the README overhaul — on branch `v0.0.2-ergonomics` (PR #2), then tag v0.0.2 published pre-release.
+
+**Spec:** docs/specs/2026-08-17-v0.0.2-ergonomics.md (binding; read fully before any task)
+
+## Global Constraints
+- CLAUDE.md's standing rules (determinism, frozen sink names, append-only enums, no fold patches, gates, no new deps, synthetic fixtures).
+- Gates per task: `cargo test`, `cargo clippy --no-deps --all-targets -- -D warnings`, `cargo fmt --check`, `cargo doc --no-deps` — all clean.
+- Every task commits to `v0.0.2-ergonomics` and pushes to the same branch on sanctuarycomputer/figmog. Commit trailer: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Schema changes are enum-variant APPENDS only (MirrorConfig, ImageBlob); reader-tuple arity updates are mechanical and must touch every destructuring site.
+
+---
+
+### Task 1: quick wins — dump/subtree, --under, --resolve-vars (spec §2, §3, §6)
+Query-layer functions + CLI flags/commands + the three tool-arg additions (`figmog_subtree` new tool → registry count +1; `under` arg on figmog_text/find/search/where; `resolve_vars` on figmog_node/subtree + styles-values path). TDD: fixture-driven tests for each (dump depth/fields projection incl. always-kept keys; under-scoping incl. page intersection + unknown-id error; resolve-vars with imported vars AND unresolved marker). Update tool-count assertions (authorized; enumerate). Commit `feat: subtree dump, --under scoping, --resolve-vars`.
+
+### Task 2: socket control plane (spec §1)
+serve listens on `<root>/serve.sock` (stale-probe logic; 0600; unlink on exit; `--no-socket`); listener thread → tagged frames → existing loop → per-connection response routing; CLI read/tools/call commands try-socket-first with transparent fallback; pull's lock error text gains the sync hint. Tests: unit (stale-probe decision), e2e (serve running: `figmog status` via socket returns fresh data with NO lock error; `figmog call figmog_sync` reaches the owning process; `--no-socket` forces the old lock error; socket removed after clean exit; second serve on same root exits with clean JSON error). Commit `feat: unix-socket control plane — CLI reads become serve clients`.
+
+### Task 3: sticky geometry (spec §4)
+`Id::MirrorConfig`/`Rec::MirrorConfig(MirrorConfigRec{geometry:bool})` appended + `mirror_config` sink appended (arity bump everywhere); pull `--geometry` flag → fetch param + config upsert; ALL re-pull paths (do_pull, serve tick, figmog_sync, auto-open) read the stored flag; `figmog_open` gains `geometry`; sweep-exempt. Tests: postcard-append safety (old-store fixture decodes — simulate by building a store pre-change? impractical; instead: unit-test that decoding a Rec encoded WITHOUT knowledge of the new variants still works — i.e. all existing round-trip tests unchanged — plus a comment; e2e: pull --geometry with a fixture containing fillGeometry keeps it in raw; re-pull keeps requesting geometry (fake-api records the query param via a URL-capturing test seam — the from-file path can't prove the param, so unit-test the URL construction). Commit `feat: sticky vector geometry pulls`.
+
+### Task 4: image bytes (spec §5)
+`Id::ImageBlob`/`Rec::ImageBlob(ImageBlobRec)` appended + `images` sink appended (arity bump); api.rs gains `images_render(key, ids, format, scale)` + `file_image_fills(key)` (trait default-Err or Option pattern consistent with variables_local); fetch+download+cache logic; CLI `figmog images` (files to --out + manifest JSON) + tool `figmog_images` (base64 content blocks ≤1MB + manifest); version eviction joins existing stale-cache sweep; 429 partial-result manifest semantics. Tests: cache round-trip + version eviction (record level); manifest shapes; tool registry count +1; fake-api driven fetch test for the two kinds; no automated live-network test (documented). Commit `feat: figmog images — version-cached renders and image fills`.
+
+### Task 5: README overhaul + SPEC.md + release prep (spec §7)
+README rewritten per spec §7 (superset positioning lead, <1 screen above the fold, compact why-table, links into SPEC.md, tight install block, single license note); docs/SPEC.md updated for ALL v0.0.2 features (socket plane, subtree, under, geometry+MirrorConfig, images+ImageBlob, resolve-vars; sink count updates); CLAUDE.md gains the struct-vs-enum-append rule; Cargo.toml version → 0.0.2. Verify every README command against a release build. Commit `docs: v0.0.2 README overhaul and spec updates`.
+
+## Reviews
+Per-task adversarial reviews (T1 read-surface; T2 concurrency/socket — most capable model; T3+T4 schema/sync; T5 docs truth), fix rounds as needed, then final whole-PR review (most capable model, file-first protocol) → merge PR #2 → tag v0.0.2 → published pre-release → verify artifact download → ping.

--- a/docs/specs/2026-08-17-v0.0.2-ergonomics.md
+++ b/docs/specs/2026-08-17-v0.0.2-ergonomics.md
@@ -1,0 +1,151 @@
+# v0.0.2 — agent ergonomics
+
+**Date:** 2026-08-17
+**Status:** Approved in discussion; this document is the binding record.
+**Driver:** field feedback from a design agent building a full replica from a
+mirrored file. The mirror's *fidelity* was sufficient; every gap was
+ergonomic — lock contention, per-node read granularity, and the two things
+Figma's file JSON omits unless asked (vector paths, image bytes).
+
+## 1. Socket control plane (reads while serve owns the store)
+
+The single-writer store means CLI reads error while `figmog serve` runs —
+the session's biggest friction. Fix it properly: serve becomes reachable.
+
+- `figmog serve` additionally listens on a **unix domain socket** at
+  `<figmog-root>/serve.sock` (created at startup, unlinked on clean exit;
+  a pre-existing socket is probed with a connect — connection-refused ⇒
+  stale, unlink and rebind; success ⇒ another serve owns this root, exit
+  with a clean JSON error).
+- Protocol over the socket: the **same newline-delimited JSON-RPC frames**
+  as stdio (initialize optional for local clients; `tools/call` accepted
+  directly). A listener thread accepts connections and forwards frames
+  into the existing serve mpsc loop tagged with a connection id;
+  responses route back to the owning connection. The store remains
+  single-threaded: socket traffic interleaves with MCP frames and watch
+  ticks exactly like any other request.
+- **CLI routing:** every read command, plus `tools` and `call`, first
+  attempts the socket for the resolved figmog-root. Socket reachable ⇒
+  the command becomes a client of serve (always-fresh, no lock, and
+  `figmog_sync` via `call` hits the *owning* process). Unreachable ⇒
+  direct store open exactly as today. `--no-socket` forces direct mode
+  (both sides: serve won't listen, CLI won't try).
+- Output contracts unchanged: same JSON on stdout, same error shapes.
+  A socket-routed command that hits a serve-side error surfaces it as the
+  standard `{"error": …}` exit-1.
+- `pull` stays direct-open (it is a writer); with serve running, `pull`
+  errors as today and the error message now ALSO says "or ask the running
+  serve: figmog call figmog_sync".
+
+Non-goals: TCP/remote access; auth on the socket (filesystem permissions
+are the boundary, socket mode 0600); Windows named pipes.
+
+## 2. Subtree dump
+
+`figmog dump <id> [--depth N] [--fields a,b,c] [--resolve-vars]` and tool
+`figmog_subtree { id (required), depth?, fields?, resolve_vars?, file? }`.
+
+- Returns the node's full `raw` JSON with `children: [...]` nested
+  recursively in child-index order, to `depth` levels (default:
+  unlimited).
+- `fields` projects every node to the named raw fields; `id`, `name`,
+  `type`, and `children` always survive projection. Unknown field names
+  are simply absent (not an error) — agents probe freely.
+- Output size is the agent's responsibility (that's what `depth`/`fields`
+  are for); the tool description says so and recommends projection.
+
+## 3. `--under <id>` subtree scoping
+
+`text`, `find`, `search`, `where` (CLI flags and the matching tools'
+optional `under` arg) accept a scope-root node id. Implementation: one
+BFS over the `children` index from the scope root collecting the
+descendant id set (root inclusive), then filter results. Composes with
+`--page` (intersection). Unknown scope id ⇒ the standard "no node …"
+error.
+
+## 4. Sticky vector geometry
+
+- `pull --geometry` adds `geometry=paths` to the file fetch, so vector
+  nodes carry `fillGeometry`/`strokeGeometry` path data in `raw`.
+- **Stickiness without a format break:** postcard structs are positional,
+  so adding a field to `FileMeta` would break decoding of existing stores.
+  Instead the flag lives in a NEW record kind — `Id::MirrorConfig` /
+  `Rec::MirrorConfig(MirrorConfigRec { geometry: bool })` — appended at
+  the enum ends (non-breaking by the append-only rule) with its own
+  `mirror_config` Table sink appended to the pipeline root. Absent row ⇒
+  geometry false (all existing stores). Sweep-exempt like Meta. CLAUDE.md
+  gains the rule this decision encodes: Rec STRUCT field changes are
+  breaking for stored data; enum-variant APPENDS are not — prefer a new
+  record kind over widening a struct.
+- Every subsequent pull of that mirror — watch tick, `figmog_sync`,
+  auto-open re-pull — reads the stored flag and requests geometry
+  accordingly, so records never churn from flag drift. Turning geometry
+  off = `pull --fresh` (documented). `figmog_open` gains optional
+  `geometry` (default false).
+
+## 5. Image bytes (`figmog images`)
+
+Explicit-only (never automatic — the images endpoints are the worst rate
+limited): `figmog images <node-id>... [--format png|svg] [--scale N]
+[--out <dir>]` and tool `figmog_images { ids (required, array), format?,
+scale?, file? }`.
+
+- Two fetch kinds behind one command:
+  - **Renders:** `GET /v1/images/:key?ids=…&format=…&scale=…` → per-node
+    image URLs → download bytes.
+  - **Fills:** for requested nodes whose `fills` reference `imageRef`
+    hashes, `GET /v1/files/:key/images` (hash→URL map, fetched at most
+    once per invocation) → download the referenced bytes.
+- **Cache:** new record kind appended to the enums —
+  `Id::ImageBlob(String)` / `Rec::ImageBlob(ImageBlobRec { key_hash,
+  kind, subject, format, scale_milli: u32, file_version, bytes:
+  Vec<u8> })` — new `images` Table sink appended to the pipeline root
+  (append-only discipline; reader-tuple arity grows — mechanical).
+  Version-keyed like `proxy_cache`; joins the same stale-eviction on
+  version-changing pulls; a repeat request on an unchanged file spends
+  zero budget.
+- Output: CLI writes files into `--out` (default `./figmog-images/`) and
+  prints a JSON manifest `[{id|ref, kind, path, bytes, cached}]`. The MCP
+  tool returns image content blocks (base64) for renders ≤ a size cap
+  (1MB each; larger ⇒ text entry with a "use the CLI --out path" note)
+  plus the manifest.
+- 429s: recorded per-item in the manifest (`error` field with
+  Retry-After), partial results returned, exit 0 if ≥1 item succeeded
+  else exit 1.
+
+## 6. `--resolve-vars`
+
+Flag on `get`, `dump` (§2), and `styles --values` (and matching tool
+args): a read-time join that annotates each `boundVariables` binding site
+with `variable_name` (from the variables table when present — Enterprise
+sync or import) and, when known, the per-mode values. Emits under a
+`resolved_variables` key alongside (never mutating) the raw data, so CSS
+generators can emit `var(--color-bg-primary)` instead of literals. When a
+bound variable has no entry in the variables table, its annotation
+carries `variable_id` plus `"source": "unresolved"` — the flag never
+errors, it just resolves what it can.
+
+## 7. README overhaul (user-directed)
+
+The README is text-heavy. Rewrite for a first-time reader:
+
+- **Lead:** one sentence — "figmog is a superset of the Figma MCP surface:
+  a local, instantly-queryable mirror of your Figma files built for
+  high-performance design agents." Then a 3-command quick start and the
+  `claude mcp add` line. Above the fold = under one screen.
+- A compact "why" table (figmog vs Figma API/MCP: latency, rate limits,
+  whole-file queries) — rows, not paragraphs.
+- Everything else gets SHORT sections with links into `docs/SPEC.md` for
+  depth (tool reference moves there; README keeps a one-line-per-tool
+  index at most). Install/verify/quarantine/glibc collapse into a tight
+  install block. Limitations become one bulleted list.
+- Tone: fewer warnings inline; the license/fold caveat stays but as one
+  clearly-marked note, not recurring prose.
+
+## 8. Delivery
+
+Branch `v0.0.2-ergonomics` → PR into main; per-task adversarial reviews
+(quick wins / socket / geometry / images / docs+release) + final
+whole-PR review; merge; tag **v0.0.2** published pre-release; README
+release-notes migration line for §4's store-format break. docs/SPEC.md
+updated for every shipped feature in the same PR.

--- a/docs/specs/2026-08-17-v0.0.2-ergonomics.md
+++ b/docs/specs/2026-08-17-v0.0.2-ergonomics.md
@@ -179,7 +179,12 @@ The README is text-heavy. Rewrite for a first-time reader:
 - Tone: fewer warnings inline; the license/fold caveat stays but as one
   clearly-marked note, not recurring prose.
 - **Writing constraints (user-directed, binding for every prose sentence
-  in the README):**
+  in the README):** the authoritative rubric is the `avoid-ai-writing`
+  skill v3.25.0 (conorbronsdon/avoid-ai-writing; a copy for the writing
+  task sits at `.superpowers/sdd/2026-08-17-v0.0.2/avoid-ai-writing-SKILL.md`).
+  The README draft is written under it, then audited against it in
+  `detect` mode before commit; the T5 review re-audits. The following
+  restate the floor and add the user's explicit rule:
   - No em-dashes anywhere. Use commas, periods, colons, or parentheses.
   - Avoid AI-writing tells: no "seamlessly", "effortlessly", "powerful",
     "supercharge", "unlock", "delve", "dive into", "robust", "leverage";

--- a/docs/specs/2026-08-17-v0.0.2-ergonomics.md
+++ b/docs/specs/2026-08-17-v0.0.2-ergonomics.md
@@ -206,6 +206,22 @@ The README is text-heavy. Rewrite for a first-time reader:
   - Read the draft aloud test: anything that sounds like a launch blog
     post gets rewritten as documentation.
 
+## 7a. "A note for Figma" README section (user-directed)
+
+A short section near the end of the README, addressed directly to Figma,
+carrying exactly two beats (final prose written by T5 under the §7
+writing constraints — friendly and direct, not snarky, no em-dashes):
+
+1. The product argument as a question: you already ship a local MCP
+   server; shouldn't it work like this, without rate limits?
+2. The open invitation, verbatim in spirit: "If you would like to use
+   this code, we would love to give it to you. Email us at
+   hello@sanctuary.computer."
+
+The section sits adjacent to (not inside) the license section; the AGPL
+note stays factual and separate so the invitation reads as goodwill, not
+terms.
+
 ## 7b. Relicense to AGPL-3.0-only (user-directed)
 
 figmog's own code moves from MIT to **AGPL-3.0-only** effective v0.0.2
@@ -215,7 +231,7 @@ holder wants absorption into proprietary products to require negotiation.
 T5's README license section states, in plain language and under the §7
 writing constraints: the project is AGPL-3.0; the v0.0.1 release remains
 MIT for that snapshot only; for licensing outside AGPL terms contact
-hugh@sanctuary.computer; figmog's license is independent of the pending
+hello@sanctuary.computer; figmog's license is independent of the pending
 upstream bogkit license, and the release-gate note about bogkit stands.
 No per-file license headers in v0.0.2 (deliberate; revisit if the
 project takes outside contributions, at which point a CLA discussion is

--- a/docs/specs/2026-08-17-v0.0.2-ergonomics.md
+++ b/docs/specs/2026-08-17-v0.0.2-ergonomics.md
@@ -178,6 +178,20 @@ The README is text-heavy. Rewrite for a first-time reader:
   install block. Limitations become one bulleted list.
 - Tone: fewer warnings inline; the license/fold caveat stays but as one
   clearly-marked note, not recurring prose.
+- **Writing constraints (user-directed, binding for every prose sentence
+  in the README):**
+  - No em-dashes anywhere. Use commas, periods, colons, or parentheses.
+  - Avoid AI-writing tells: no "seamlessly", "effortlessly", "powerful",
+    "supercharge", "unlock", "delve", "dive into", "robust", "leverage";
+    no "it's not just X, it's Y" constructions; no triads of adjectives
+    or rule-of-three flourishes; no sentences that restate the previous
+    sentence with synonyms; no "**Bold phrase:** explanation" list spam
+    outside genuine reference tables.
+  - Short declarative sentences. Concrete nouns and measured numbers
+    instead of adjectives. If a sentence would survive in any product's
+    README, cut it or make it specific to figmog.
+  - Read the draft aloud test: anything that sounds like a launch blog
+    post gets rewritten as documentation.
 
 ## 8. Delivery
 

--- a/docs/specs/2026-08-17-v0.0.2-ergonomics.md
+++ b/docs/specs/2026-08-17-v0.0.2-ergonomics.md
@@ -158,7 +158,20 @@ The README is text-heavy. Rewrite for a first-time reader:
   The CLI-first usage (`figmog pull` / `search` / …) moves BELOW this as
   the second path, for humans.
 - A compact "why" table (figmog vs Figma API/MCP: latency, rate limits,
-  whole-file queries) — rows, not paragraphs.
+  whole-file queries) — rows, not paragraphs — backed by REAL measured
+  numbers (user-supplied run, 2026-08-17, real 5,339-node production
+  file, Apple Silicon, API comparison included):
+  - Headline line above the fold: node read p50 **0.055ms vs 972.6ms**
+    via the API — **17,657× faster**; **149 req/s** sustained vs Figma's
+    ~10 Tier-1 requests/minute; re-sync of the unchanged file **4.6ms,
+    zero churn**; the 5,000-query load = 33.6s vs ≈500 minutes at the
+    API's budget.
+  - Full per-tool table (search .067 / node .055 / tree .46 /
+    instances .11 / where 22.1 / stats 16.9 ms p50, plus p95/p99/max and
+    the sync-phase numbers) inside a `<details>` block.
+  - Provenance sentence: measured with the project's load-test harness
+    (retired from the binary in v0.0.1's slim-down; lives in the repo
+    history), against a real file with 5 live API comparison calls.
 - Everything else gets SHORT sections with links into `docs/SPEC.md` for
   depth (tool reference moves there; README keeps a one-line-per-tool
   index at most). Install/verify/quarantine/glibc collapse into a tight

--- a/docs/specs/2026-08-17-v0.0.2-ergonomics.md
+++ b/docs/specs/2026-08-17-v0.0.2-ergonomics.md
@@ -54,6 +54,19 @@ are the boundary, socket mode 0600); Windows named pipes.
 - Output size is the agent's responsibility (that's what `depth`/`fields`
   are for); the tool description says so and recommends projection.
 
+## 2b. URL-addressed nodes
+
+The README's promised prompt pastes a Figma *frame URL*. Every node-id
+input (tools' `id`/`under`/`target` args and the matching CLI args)
+therefore accepts, in addition to bare ids: a full Figma URL carrying
+`?node-id=…` (or `node-id=` anywhere in the query). Extraction:
+`ident::parse_node_ref(input) -> Option<(Option<file_key>, node_id)>` —
+node id normalized (`0-1` ⇒ `0:1`). When the URL also names a file and
+the tool's `file` arg is absent, the URL's file key is used as the file
+argument (auto-open semantics apply); when both are present and disagree,
+the explicit `file` arg wins and the mismatch is noted in the error if
+the node isn't found. Bare ids behave exactly as today.
+
 ## 3. `--under <id>` subtree scoping
 
 `text`, `find`, `search`, `where` (CLI flags and the matching tools'
@@ -131,8 +144,19 @@ The README is text-heavy. Rewrite for a first-time reader:
 
 - **Lead:** one sentence — "figmog is a superset of the Figma MCP surface:
   a local, instantly-queryable mirror of your Figma files built for
-  high-performance design agents." Then a 3-command quick start and the
-  `claude mcp add` line. Above the fold = under one screen.
+  high-performance design agents." Above the fold = under one screen.
+- **Quick start (user-directed shape — the Claude path comes FIRST):**
+  1. Download/untar the release binary (one compact block).
+  2. `export FIGMA_TOKEN=figd_…`
+  3. `claude mcp add figmog -- $PWD/figmog serve`
+  4. Then, verbatim as a quoted example prompt:
+     > Using figmog, pull this file: [figma file URL], then build this
+     > frame in HTML & CSS: [figma frame URL]
+     with one sentence noting figmog mirrors the file on first reference
+     and the agent's reads are instant from then on. (Frame URLs carry
+     `?node-id=…` — figmog's tools accept them directly.)
+  The CLI-first usage (`figmog pull` / `search` / …) moves BELOW this as
+  the second path, for humans.
 - A compact "why" table (figmog vs Figma API/MCP: latency, rate limits,
   whole-file queries) — rows, not paragraphs.
 - Everything else gets SHORT sections with links into `docs/SPEC.md` for

--- a/docs/specs/2026-08-17-v0.0.2-ergonomics.md
+++ b/docs/specs/2026-08-17-v0.0.2-ergonomics.md
@@ -149,6 +149,14 @@ The README is text-heavy. Rewrite for a first-time reader:
   1. Download/untar the release binary (one compact block).
   2. `export FIGMA_TOKEN=figd_…`
   3. `claude mcp add figmog -- $PWD/figmog serve`
+  3b. **Remove the official Figma MCP server if connected** (user-directed
+      quick-start step): `claude mcp list` to find its name (commonly
+      `figma`), then `claude mcp remove figma`. State the rule plainly:
+      run one or the other, not both. figmog already forwards the official
+      server's tools (with caching) when the Figma desktop app is running,
+      so removing the direct connection loses nothing; keeping both gives
+      the agent two overlapping Figma servers and it will pick tools
+      badly.
   4. Then, verbatim as a quoted example prompt:
      > Using figmog, pull this file: [figma file URL], then build this
      > frame in HTML & CSS: [figma frame URL]

--- a/docs/specs/2026-08-17-v0.0.2-ergonomics.md
+++ b/docs/specs/2026-08-17-v0.0.2-ergonomics.md
@@ -206,6 +206,21 @@ The README is text-heavy. Rewrite for a first-time reader:
   - Read the draft aloud test: anything that sounds like a launch blog
     post gets rewritten as documentation.
 
+## 7b. Relicense to AGPL-3.0-only (user-directed)
+
+figmog's own code moves from MIT to **AGPL-3.0-only** effective v0.0.2
+(LICENSE = canonical AGPL text; Cargo.toml `license = "AGPL-3.0-only"` —
+both already committed by the controller). Rationale: the copyright
+holder wants absorption into proprietary products to require negotiation.
+T5's README license section states, in plain language and under the §7
+writing constraints: the project is AGPL-3.0; the v0.0.1 release remains
+MIT for that snapshot only; for licensing outside AGPL terms contact
+hugh@sanctuary.computer; figmog's license is independent of the pending
+upstream bogkit license, and the release-gate note about bogkit stands.
+No per-file license headers in v0.0.2 (deliberate; revisit if the
+project takes outside contributions, at which point a CLA discussion is
+also due — noted in CLAUDE.md by T5).
+
 ## 8. Delivery
 
 Branch `v0.0.2-ergonomics` → PR into main; per-task adversarial reviews

--- a/src/api.rs
+++ b/src/api.rs
@@ -53,6 +53,38 @@ pub trait FigmaApi {
         let _ = key;
         Ok(None)
     }
+    /// `GET /v1/images/:key?ids=…&format=…[&scale=…]` (v0.0.2 spec §5) —
+    /// node renders. Unlike `variables_local`'s "not on this plan, and
+    /// that's fine" gating, an unimplemented render endpoint is a genuine
+    /// capability gap for any caller that reaches it, so the default
+    /// returns an error rather than `Ok(None)`: existing `FigmaApi` test
+    /// doubles built before this method existed (e.g. `watch::tests::
+    /// Script`) keep compiling without knowing renders exist at all, and
+    /// `crate::images::fetch` surfaces this as a normal per-item manifest
+    /// error rather than a panic if a caller ever did reach it.
+    fn images_render(
+        &self,
+        key: &str,
+        ids: &[String],
+        format: &str,
+        scale: Option<f64>,
+    ) -> Result<Value, ApiError> {
+        let _ = (key, ids, format, scale);
+        Err(ApiError::Http {
+            status: 501,
+            msg: "images_render not implemented".into(),
+        })
+    }
+    /// `GET /v1/files/:key/images` (v0.0.2 spec §5) — the file's fill
+    /// image hash→URL map. Same default-Err reasoning as
+    /// [`Self::images_render`].
+    fn file_image_fills(&self, key: &str) -> Result<Value, ApiError> {
+        let _ = key;
+        Err(ApiError::Http {
+            status: 501,
+            msg: "file_image_fills not implemented".into(),
+        })
+    }
 }
 
 pub(crate) fn parse_meta_response(v: &Value) -> Result<FileMetaResp, ApiError> {
@@ -85,6 +117,30 @@ pub(crate) fn file_url(key: &str, geometry: bool) -> String {
     } else {
         format!("/v1/files/{key}")
     }
+}
+
+/// `GET /v1/images/:key` request path (v0.0.2 spec §5) — comma-joined
+/// `ids`, `format`, and `scale` when given. Split out as a pure function
+/// for the same reason as [`file_url`]: unit-testable request-shape
+/// coverage without a live HTTP call.
+pub(crate) fn images_render_url(
+    key: &str,
+    ids: &[String],
+    format: &str,
+    scale: Option<f64>,
+) -> String {
+    let ids_param = ids.join(",");
+    let mut url = format!("/v1/images/{key}?ids={ids_param}&format={format}");
+    if let Some(s) = scale {
+        url.push_str(&format!("&scale={s}"));
+    }
+    url
+}
+
+/// `GET /v1/files/:key/images` request path (v0.0.2 spec §5) — the fill
+/// image hash→URL map, no query parameters.
+pub(crate) fn file_image_fills_url(key: &str) -> String {
+    format!("/v1/files/{key}/images")
 }
 
 pub(crate) fn error_from_status(status: u16, retry_after: Option<&str>, msg: String) -> ApiError {
@@ -145,6 +201,47 @@ impl FigmaApi for UreqApi {
             Err(e) if variables_local_is_gated(&e) => Ok(None),
             Err(e) => Err(e),
         }
+    }
+    fn images_render(
+        &self,
+        key: &str,
+        ids: &[String],
+        format: &str,
+        scale: Option<f64>,
+    ) -> Result<Value, ApiError> {
+        self.get_json(&images_render_url(key, ids, format, scale))
+    }
+    fn file_image_fills(&self, key: &str) -> Result<Value, ApiError> {
+        self.get_json(&file_image_fills_url(key))
+    }
+}
+
+/// Plain byte download for an already-resolved image URL (v0.0.2 spec
+/// §5): the URLs `images_render`/`file_image_fills` return are pre-signed
+/// S3 links, not `api.figma.com` — no `X-Figma-Token` header (S3 rejects
+/// an unexpected auth header on a pre-signed URL), and no `base_url`
+/// override (these are always absolute URLs from Figma's own response,
+/// never a path this crate constructs). A free function rather than a
+/// `FigmaApi` method: it isn't a Figma API call at all, and keeping it
+/// free lets `crate::images::fetch` accept it as a plain
+/// `&dyn Fn(&str) -> Result<Vec<u8>, ApiError>`, injectable by tests
+/// without a `FigmaApi` implementor standing in for a plain HTTP GET.
+pub fn download_bytes(url: &str) -> Result<Vec<u8>, ApiError> {
+    match ureq::get(url).call() {
+        Ok(resp) => {
+            let mut buf = Vec::new();
+            use std::io::Read;
+            resp.into_reader()
+                .read_to_end(&mut buf)
+                .map_err(|e| ApiError::Network(e.to_string()))?;
+            Ok(buf)
+        }
+        Err(ureq::Error::Status(status, resp)) => {
+            let retry = resp.header("Retry-After").map(str::to_string);
+            let msg = resp.into_string().unwrap_or_default();
+            Err(error_from_status(status, retry.as_deref(), msg))
+        }
+        Err(e) => Err(ApiError::Network(e.to_string())),
     }
 }
 
@@ -246,5 +343,43 @@ mod tests {
     fn file_url_adds_geometry_paths_only_when_requested() {
         assert_eq!(file_url("ABC123", false), "/v1/files/ABC123");
         assert_eq!(file_url("ABC123", true), "/v1/files/ABC123?geometry=paths");
+    }
+
+    // ---- image bytes (v0.0.2 spec §5) ----
+
+    #[test]
+    fn images_render_url_joins_ids_and_omits_scale_when_absent() {
+        let ids = vec!["1:2".to_string(), "1:3".to_string()];
+        assert_eq!(
+            images_render_url("ABC123", &ids, "png", None),
+            "/v1/images/ABC123?ids=1:2,1:3&format=png"
+        );
+    }
+
+    #[test]
+    fn images_render_url_appends_scale_when_given() {
+        let ids = vec!["1:2".to_string()];
+        assert_eq!(
+            images_render_url("ABC123", &ids, "svg", Some(2.0)),
+            "/v1/images/ABC123?ids=1:2&format=svg&scale=2"
+        );
+    }
+
+    #[test]
+    fn file_image_fills_url_has_no_query() {
+        assert_eq!(file_image_fills_url("ABC123"), "/v1/files/ABC123/images");
+    }
+
+    /// Default (unimplemented) `images_render`/`file_image_fills`
+    /// return an error, not `Ok(None)` — see this trait's own doc comment
+    /// on why that differs from `variables_local`'s default.
+    #[test]
+    fn default_images_render_and_file_image_fills_are_errors() {
+        assert!(
+            NoVariablesOverride
+                .images_render("ABC", &[], "png", None)
+                .is_err()
+        );
+        assert!(NoVariablesOverride.file_image_fills("ABC").is_err());
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -35,8 +35,15 @@ pub struct FileMetaResp {
 pub trait FigmaApi {
     /// `GET /v1/files/:key/meta` — Tier 3, cheap enough to poll.
     fn file_meta(&self, key: &str) -> Result<FileMetaResp, ApiError>;
-    /// `GET /v1/files/:key` — Tier 1, the full document tree.
-    fn file(&self, key: &str) -> Result<Value, ApiError>;
+    /// `GET /v1/files/:key` — Tier 1, the full document tree. `geometry`
+    /// (v0.0.2 spec §4) adds `?geometry=paths`, so vector nodes carry
+    /// `fillGeometry`/`strokeGeometry` path data in the response — the
+    /// caller (`cli::pull::do_pull`, `sessions`'s pull closure) is
+    /// responsible for combining this call's own override with whatever
+    /// geometry setting is already stored (`store::effective_geometry`)
+    /// before deciding what to pass here; this trait method itself just
+    /// forwards the bit to the request.
+    fn file(&self, key: &str, geometry: bool) -> Result<Value, ApiError>;
     /// `GET /v1/files/:key/variables/local` — Enterprise-only. `Ok(None)`
     /// means "not available on this plan" (never an error: `pull` falls
     /// back to v1 behavior). The default implementation always returns
@@ -62,6 +69,22 @@ pub(crate) fn parse_meta_response(v: &Value) -> Result<FileMetaResp, ApiError> {
         name: get("name")?,
         last_touched_at: get("last_touched_at")?,
     })
+}
+
+/// `GET /v1/files/:key` request path, with `?geometry=paths` appended when
+/// `geometry` (v0.0.2 spec §4). Split out from [`UreqApi::file`] as a pure
+/// function so the query-parameter construction is unit-testable without a
+/// live HTTP call — `UreqApi::with_base_url` has no fixture server to
+/// assert against in this crate's test suite, so this is the seam that
+/// proves the request shape (spec §4's stickiness tests lean on this for
+/// the "what would this pull have asked for" half; the from-file path
+/// never issues the request at all).
+pub(crate) fn file_url(key: &str, geometry: bool) -> String {
+    if geometry {
+        format!("/v1/files/{key}?geometry=paths")
+    } else {
+        format!("/v1/files/{key}")
+    }
 }
 
 pub(crate) fn error_from_status(status: u16, retry_after: Option<&str>, msg: String) -> ApiError {
@@ -113,8 +136,8 @@ impl FigmaApi for UreqApi {
     fn file_meta(&self, key: &str) -> Result<FileMetaResp, ApiError> {
         parse_meta_response(&self.get_json(&format!("/v1/files/{key}/meta"))?)
     }
-    fn file(&self, key: &str) -> Result<Value, ApiError> {
-        self.get_json(&format!("/v1/files/{key}"))
+    fn file(&self, key: &str, geometry: bool) -> Result<Value, ApiError> {
+        self.get_json(&file_url(key, geometry))
     }
     fn variables_local(&self, key: &str) -> Result<Option<Value>, ApiError> {
         match self.get_json(&format!("/v1/files/{key}/variables/local")) {
@@ -204,7 +227,7 @@ mod tests {
         fn file_meta(&self, _key: &str) -> Result<FileMetaResp, ApiError> {
             unimplemented!("not exercised by this test")
         }
-        fn file(&self, _key: &str) -> Result<Value, ApiError> {
+        fn file(&self, _key: &str, _geometry: bool) -> Result<Value, ApiError> {
             unimplemented!("not exercised by this test")
         }
     }
@@ -215,5 +238,13 @@ mod tests {
             NoVariablesOverride.variables_local("ABC123"),
             Ok(None)
         ));
+    }
+
+    // ---- sticky vector geometry (v0.0.2 spec §4) ----
+
+    #[test]
+    fn file_url_adds_geometry_paths_only_when_requested() {
+        assert_eq!(file_url("ABC123", false), "/v1/files/ABC123");
+        assert_eq!(file_url("ABC123", true), "/v1/files/ABC123?geometry=paths");
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -143,7 +143,7 @@ mod tests {
             );
         });
 
-        let hit = st.rtx(|(_, _, _, _, _, _, _, cache)| {
+        let hit = st.rtx(|(_, _, _, _, _, _, _, cache, _)| {
             lookup(&cache, requested_tool, requested_args, "100")
         });
         assert_eq!(hit, None, "a key-hash collision must never be served");
@@ -170,7 +170,7 @@ mod tests {
             tx.upsert(&Id::ProxyCache(key.clone()), &Rec::ProxyCache(rec));
         });
 
-        let hit = st.rtx(|(_, _, _, _, _, _, _, cache)| lookup(&cache, tool, args, "100"));
+        let hit = st.rtx(|(_, _, _, _, _, _, _, cache, _)| lookup(&cache, tool, args, "100"));
         assert_eq!(hit, Some(Value::String("real data".into())));
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -143,7 +143,7 @@ mod tests {
             );
         });
 
-        let hit = st.rtx(|(_, _, _, _, _, _, _, cache, _)| {
+        let hit = st.rtx(|(_, _, _, _, _, _, _, cache, _, _)| {
             lookup(&cache, requested_tool, requested_args, "100")
         });
         assert_eq!(hit, None, "a key-hash collision must never be served");
@@ -170,7 +170,7 @@ mod tests {
             tx.upsert(&Id::ProxyCache(key.clone()), &Rec::ProxyCache(rec));
         });
 
-        let hit = st.rtx(|(_, _, _, _, _, _, _, cache, _)| lookup(&cache, tool, args, "100"));
+        let hit = st.rtx(|(_, _, _, _, _, _, _, cache, _, _)| lookup(&cache, tool, args, "100"));
         assert_eq!(hit, Some(Value::String("real data".into())));
     }
 }

--- a/src/cli/call.rs
+++ b/src/cli/call.rs
@@ -137,7 +137,7 @@ pub(super) fn cmd_call(
             .ok_or_else(|| format!("upstream not attached: {tool}"))?;
         let args_canonical = proxy::canonical_args(&args)?;
         let version_and_hit = if proxy::is_cacheable(&tool, &args) {
-            st.rtx(|(_, _, _, _, _, _, meta, cache, _)| {
+            st.rtx(|(_, _, _, _, _, _, meta, cache, _, _)| {
                 let version = meta.get(&0).map(|m| m.version.clone());
                 let hit = version
                     .as_ref()

--- a/src/cli/call.rs
+++ b/src/cli/call.rs
@@ -113,7 +113,11 @@ pub(super) fn cmd_call(
     // second handle for `figmog_sync`, since it reuses its own long-lived
     // `st` instead of calling `do_pull`).
     if tool == "figmog_sync" {
-        let result = do_pull(db, None, None, false)
+        // `geometry: false` here means "no new override" — `do_pull`
+        // internally unions this with whatever's already stored (spec §4
+        // stickiness), so a plain `figmog_sync` still re-requests geometry
+        // for a mirror that was ever pulled with `--geometry`.
+        let result = do_pull(db, None, None, false, false)
             .map(|(churn, _name, _version)| serde_json::to_value(&churn).unwrap_or_default())
             .map_err(|e| e.to_string());
         return print_call_result(result);
@@ -133,7 +137,7 @@ pub(super) fn cmd_call(
             .ok_or_else(|| format!("upstream not attached: {tool}"))?;
         let args_canonical = proxy::canonical_args(&args)?;
         let version_and_hit = if proxy::is_cacheable(&tool, &args) {
-            st.rtx(|(_, _, _, _, _, _, meta, cache)| {
+            st.rtx(|(_, _, _, _, _, _, meta, cache, _)| {
                 let version = meta.get(&0).map(|m| m.version.clone());
                 let hit = version
                     .as_ref()

--- a/src/cli/images.rs
+++ b/src/cli/images.rs
@@ -184,12 +184,27 @@ fn from_socket_result(result: Value) -> Result<Vec<Fetched>, String> {
             let subject = entry.get("id").or_else(|| entry.get("ref"));
             let data = subject.and_then(|subject| {
                 content.iter().skip(1).find_map(|block| {
-                    let matches = block.get("id").or_else(|| block.get("ref")) == Some(subject);
-                    let is_image = block.get("type").and_then(Value::as_str) == Some("image");
-                    (matches && is_image)
-                        .then(|| block.get("data").and_then(Value::as_str))
-                        .flatten()
-                        .and_then(|b64| images::base64_decode(b64).ok())
+                    if block.get("id").or_else(|| block.get("ref")) != Some(subject) {
+                        return None;
+                    }
+                    // `images::to_mcp_content`'s own contract: a payload
+                    // block (image OR svg-as-text) always carries
+                    // `mimeType`; an "oversized, use --out" note never
+                    // does — that field's presence, not the block's
+                    // `type` alone, is what tells the two `text` shapes
+                    // apart (see that function's doc comment).
+                    block.get("mimeType")?;
+                    match block.get("type").and_then(Value::as_str) {
+                        Some("image") => block
+                            .get("data")
+                            .and_then(Value::as_str)
+                            .and_then(|b64| images::base64_decode(b64).ok()),
+                        Some("text") => block
+                            .get("text")
+                            .and_then(Value::as_str)
+                            .map(|s| s.as_bytes().to_vec()),
+                        _ => None,
+                    }
                 })
             });
             Fetched { entry, data }
@@ -251,6 +266,46 @@ mod tests {
         assert_eq!(fetched.len(), 2);
         assert_eq!(fetched[0].data, Some(vec![1, 2, 3]));
         assert_eq!(fetched[1].data, None);
+    }
+
+    /// SVG ruling: an SVG render's payload arrives as a `text` block
+    /// (never `image`), distinguished from a plain oversized note by the
+    /// `mimeType` field's presence — `from_socket_result` must decode it
+    /// back to bytes via the `text` field, not treat it as "no data" just
+    /// because its `type` isn't `image`.
+    #[test]
+    fn from_socket_result_decodes_svg_text_payload_by_mimetype_marker() {
+        let svg = "<svg><rect/></svg>";
+        let result = json!({
+            "isError": false,
+            "content": [
+                {"type": "text", "text": serde_json::to_string(&json!([
+                    {"id": "1:2", "kind": "render", "format": "svg", "bytes": svg.len(), "cached": false},
+                ])).unwrap()},
+                {"type": "text", "id": "1:2", "text": svg, "mimeType": "image/svg+xml"},
+            ],
+        });
+        let fetched = from_socket_result(result).unwrap();
+        assert_eq!(fetched.len(), 1);
+        assert_eq!(fetched[0].data, Some(svg.as_bytes().to_vec()));
+    }
+
+    /// An oversized-note `text` block (no `mimeType`) must never be
+    /// mistaken for an SVG payload just because both are `type: "text"`.
+    #[test]
+    fn from_socket_result_does_not_mistake_an_oversized_note_for_svg_payload() {
+        let result = json!({
+            "isError": false,
+            "content": [
+                {"type": "text", "text": serde_json::to_string(&json!([
+                    {"id": "1:2", "kind": "render", "format": "svg", "bytes": 2_000_000, "cached": false},
+                ])).unwrap()},
+                {"type": "text", "id": "1:2", "text": "too large, use --out"},
+            ],
+        });
+        let fetched = from_socket_result(result).unwrap();
+        assert_eq!(fetched.len(), 1);
+        assert_eq!(fetched[0].data, None);
     }
 
     #[test]

--- a/src/cli/images.rs
+++ b/src/cli/images.rs
@@ -9,8 +9,11 @@
 //! lock" for free, because this command writes too). Socket reachable ⇒
 //! route through the very `figmog_images` tool `figmog serve` itself
 //! exposes (spec: "the tool path must exist anyway" — serve owns the
-//! caching); unreachable, or `--no-socket` ⇒ direct network + direct store
-//! open, exactly like `pull`.
+//! caching); unreachable, `--no-socket`, or `--db` ⇒ direct network +
+//! direct store open, exactly like `pull` (spec §10: `--db` names a store
+//! rather than a root, so it bypasses the socket entirely, same as every
+//! other routed command — see `cli::dispatch`'s own `cli.db.is_none()`
+//! gate).
 //!
 //! **Manifest shape**, identical on both paths:
 //! `[{id|ref, kind, format, bytes, cached, path?, error?}]` — `bytes` is
@@ -33,6 +36,7 @@ use super::{Db, open_store_checked, socket, write_json};
 pub(super) fn cmd_images(
     db: &Db,
     no_socket: bool,
+    db_given: bool,
     ids: Vec<String>,
     format: String,
     scale: Option<f64>,
@@ -41,6 +45,7 @@ pub(super) fn cmd_images(
     let out_dir = out.unwrap_or_else(|| PathBuf::from("figmog-images"));
 
     let fetched = if !no_socket
+        && !db_given
         && let Some(result) = socket::try_images_call(
             Path::new(socket::DEFAULT_ROOT),
             json!({"ids": ids, "format": format, "scale": scale, "file": db.key}),

--- a/src/cli/images.rs
+++ b/src/cli/images.rs
@@ -1,0 +1,264 @@
+//! `figmog images` (v0.0.2 spec §5): download node renders and/or fill
+//! images to `--out`, printing a JSON manifest.
+//!
+//! **Routing.** Images spends Figma API budget *and* needs to write cache
+//! rows into the mirror's store, so it can't safely open the store
+//! directly while `figmog serve` holds it (the same lock-contention
+//! concern `cli::pull`'s own doc comment documents — unlike every other
+//! read command, a running serve doesn't make this "always fresh, no
+//! lock" for free, because this command writes too). Socket reachable ⇒
+//! route through the very `figmog_images` tool `figmog serve` itself
+//! exposes (spec: "the tool path must exist anyway" — serve owns the
+//! caching); unreachable, or `--no-socket` ⇒ direct network + direct store
+//! open, exactly like `pull`.
+//!
+//! **Manifest shape**, identical on both paths:
+//! `[{id|ref, kind, format, bytes, cached, path?, error?}]` — `bytes` is
+//! always a byte *count*; `path` is present only for an item this
+//! invocation actually wrote to disk. Exit 0 if at least one item wrote
+//! successfully, else 1 — but the manifest is always the stdout payload,
+//! even on the all-failed path (spec: "no-token error path produces
+//! manifest-shaped error JSON, exit 1" — this command never falls through
+//! to the generic `{"error": ...}` shape other commands use).
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Value, json};
+
+use crate::api::{FigmaApi, UreqApi};
+use crate::images;
+
+use super::{Db, open_store_checked, socket, write_json};
+
+pub(super) fn cmd_images(
+    db: &Db,
+    no_socket: bool,
+    ids: Vec<String>,
+    format: String,
+    scale: Option<f64>,
+    out: Option<PathBuf>,
+) -> Result<(), String> {
+    let out_dir = out.unwrap_or_else(|| PathBuf::from("figmog-images"));
+
+    let fetched = if !no_socket
+        && let Some(result) = socket::try_images_call(
+            Path::new(socket::DEFAULT_ROOT),
+            json!({"ids": ids, "format": format, "scale": scale, "file": db.key}),
+        ) {
+        from_socket_result(result?)?
+    } else {
+        fetch_direct(db, &ids, &format, scale)?
+    };
+
+    std::fs::create_dir_all(&out_dir)
+        .map_err(|e| format!("creating {}: {e}", out_dir.display()))?;
+
+    let mut manifest = Vec::with_capacity(fetched.len());
+    let mut wrote_any = false;
+    for item in fetched {
+        let mut entry = item.entry;
+        match item.data {
+            Some(bytes) => {
+                let path = out_dir.join(filename(&entry));
+                std::fs::write(&path, &bytes)
+                    .map_err(|e| format!("writing {}: {e}", path.display()))?;
+                if let Some(obj) = entry.as_object_mut() {
+                    obj.insert("path".to_string(), json!(path.display().to_string()));
+                }
+                wrote_any = true;
+            }
+            None => {
+                // No bytes to write: either this item's own `error` field
+                // already explains why, or (a socket-routed >1MB item) we
+                // synthesize one — the manifest is never silently missing
+                // a reason a real file didn't show up.
+                if let Some(obj) = entry.as_object_mut()
+                    && !obj.contains_key("error")
+                {
+                    obj.insert(
+                        "error".to_string(),
+                        json!(
+                            "too large to relay over the socket-routed tool call (>1MB) — stop `figmog serve` for this file, or use --no-socket, to fetch it directly"
+                        ),
+                    );
+                }
+            }
+        }
+        manifest.push(entry);
+    }
+
+    write_json(&Value::Array(manifest))?;
+    if !wrote_any {
+        // The manifest above is already on stdout — this is the "exit 1,
+        // but still manifest-shaped JSON" path (spec §5), not the generic
+        // `{"error": ...}` exit-1 shape `run()` builds from an `Err`. See
+        // this module's doc comment.
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// One fetched-or-not item, ready to write: `entry` is always the
+/// manifest row (built by `images::ImageItem::manifest_entry`, or parsed
+/// from a socket-routed tool response's own manifest text block); `data`
+/// is the bytes to write to disk when this invocation actually has them.
+#[derive(Debug)]
+struct Fetched {
+    entry: Value,
+    data: Option<Vec<u8>>,
+}
+
+fn fetch_direct(
+    db: &Db,
+    ids: &[String],
+    format: &str,
+    scale: Option<f64>,
+) -> Result<Vec<Fetched>, String> {
+    let key = db
+        .key
+        .clone()
+        .ok_or_else(|| "no file key: pass a file key or figma.com URL".to_string())?;
+    let node_ids = images::normalize_ids(ids);
+    let scale_m = images::scale_milli(scale);
+    let mut st = open_store_checked(|| crate::open_store!(&db.path))?;
+    let scanned = st.rtx(|((nodes, ..), _, _, _, _, _, meta, _, _, images_table)| {
+        images::scan(&nodes, &meta, &images_table, &node_ids, format, scale_m)
+    });
+    let token = std::env::var("FIGMA_TOKEN").ok();
+    let api = token.map(UreqApi::new);
+    let download = crate::api::download_bytes;
+    let items = images::resolve(
+        &mut st,
+        scanned,
+        api.as_ref().map(|a| a as &dyn FigmaApi),
+        &download,
+        &key,
+        &node_ids,
+        format,
+        scale,
+    );
+    Ok(items
+        .into_iter()
+        .map(|item| {
+            let entry = item.manifest_entry();
+            let data = item.error.is_none().then_some(item.bytes);
+            Fetched { entry, data }
+        })
+        .collect())
+}
+
+/// Decode a socket-routed `figmog_images` tool result (the raw MCP
+/// `{"content": [...], "isError": ...}` object — see
+/// `socket::try_images_call`'s own doc comment for why this bypasses the
+/// generic `interpret_call_response`) back into [`Fetched`] rows: the
+/// manifest lives in `content[0]`'s text (always present, always first —
+/// `images::to_mcp_content`'s own ordering contract), and every
+/// `image`/oversized-`text` block after it carries the same `id`/`ref` tag
+/// as its manifest row, matched by that tag rather than by position (an
+/// oversized item's block is `text`, not `image`, at whatever position it
+/// falls — see `images::to_mcp_content`).
+fn from_socket_result(result: Value) -> Result<Vec<Fetched>, String> {
+    if result.get("isError").and_then(Value::as_bool) == Some(true) {
+        let msg = result["content"][0]["text"]
+            .as_str()
+            .unwrap_or("unknown error from serve")
+            .to_string();
+        return Err(msg);
+    }
+    let content = result
+        .get("content")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let manifest_text = content
+        .first()
+        .and_then(|b| b.get("text"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| "serve returned an images result with no manifest block".to_string())?;
+    let manifest: Vec<Value> = serde_json::from_str(manifest_text)
+        .map_err(|e| format!("serve returned a non-JSON images manifest: {e}"))?;
+
+    Ok(manifest
+        .into_iter()
+        .map(|entry| {
+            let subject = entry.get("id").or_else(|| entry.get("ref"));
+            let data = subject.and_then(|subject| {
+                content.iter().skip(1).find_map(|block| {
+                    let matches = block.get("id").or_else(|| block.get("ref")) == Some(subject);
+                    let is_image = block.get("type").and_then(Value::as_str) == Some("image");
+                    (matches && is_image)
+                        .then(|| block.get("data").and_then(Value::as_str))
+                        .flatten()
+                        .and_then(|b64| images::base64_decode(b64).ok())
+                })
+            });
+            Fetched { entry, data }
+        })
+        .collect())
+}
+
+/// `<out>/<kind>-<sanitized subject>.<format>` — node ids/imageRef hashes
+/// never contain `/`, but node ids do contain `:` (not a safe bare
+/// filename character on every platform figmog might run on), so it's
+/// replaced.
+fn filename(entry: &Value) -> String {
+    let kind = entry["kind"].as_str().unwrap_or("image");
+    let subject = entry["id"]
+        .as_str()
+        .or_else(|| entry["ref"].as_str())
+        .unwrap_or("unknown");
+    let format = entry["format"]
+        .as_str()
+        .filter(|f| !f.is_empty())
+        .unwrap_or("bin");
+    let safe_subject = subject.replace([':', '/', '\\'], "-");
+    format!("{kind}-{safe_subject}.{format}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filename_sanitizes_node_id_colons() {
+        let entry = json!({"id": "1:2", "kind": "render", "format": "png"});
+        assert_eq!(filename(&entry), "render-1-2.png");
+    }
+
+    #[test]
+    fn filename_uses_ref_for_fills() {
+        let entry = json!({"ref": "hash123", "kind": "fill", "format": "jpg"});
+        assert_eq!(filename(&entry), "fill-hash123.jpg");
+    }
+
+    #[test]
+    fn from_socket_result_matches_image_blocks_by_tag_not_position() {
+        // Deliberately out-of-order relative to the manifest, and with an
+        // oversized (text-only) second item interleaved, to prove the
+        // match is tag-based.
+        let result = json!({
+            "isError": false,
+            "content": [
+                {"type": "text", "text": serde_json::to_string(&json!([
+                    {"id": "1:2", "kind": "render", "format": "png", "bytes": 3, "cached": false},
+                    {"id": "1:3", "kind": "render", "format": "png", "bytes": 2_000_000, "cached": false},
+                ])).unwrap()},
+                {"type": "text", "id": "1:3", "text": "oversized note"},
+                {"type": "image", "id": "1:2", "data": "AQID", "mimeType": "image/png"},
+            ],
+        });
+        let fetched = from_socket_result(result).unwrap();
+        assert_eq!(fetched.len(), 2);
+        assert_eq!(fetched[0].data, Some(vec![1, 2, 3]));
+        assert_eq!(fetched[1].data, None);
+    }
+
+    #[test]
+    fn from_socket_result_propagates_is_error() {
+        let result = json!({
+            "isError": true,
+            "content": [{"type": "text", "text": "no such file"}],
+        });
+        assert_eq!(from_socket_result(result).unwrap_err(), "no such file");
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -111,19 +111,43 @@ enum Cmd {
         id: String,
         #[arg(long)]
         children: bool,
+        /// Annotate `boundVariables` binding sites with variable names and
+        /// per-mode values under a `resolved_variables` key.
+        #[arg(long)]
+        resolve_vars: bool,
     },
-    /// Nodes by type, optionally within one page.
+    /// Full raw JSON subtree dump rooted at a node (default depth: unlimited).
+    Dump {
+        id: String,
+        #[arg(long)]
+        depth: Option<usize>,
+        /// Project every node to these raw fields (id/name/type/children
+        /// always survive). Comma-separated, e.g. --fields id,name,fills.
+        #[arg(long, value_delimiter = ',')]
+        fields: Option<Vec<String>>,
+        /// Annotate `boundVariables` binding sites with variable names and
+        /// per-mode values under a `resolved_variables` key.
+        #[arg(long)]
+        resolve_vars: bool,
+    },
+    /// Nodes by type, optionally within one page and/or a subtree scope.
     Find {
         #[arg(long = "type")]
         node_type: String,
         #[arg(long)]
         page: Option<String>,
+        /// Scope to the subtree rooted at this node id (inclusive).
+        #[arg(long)]
+        under: Option<String>,
     },
     /// BM25 search over layer names and text content.
     Search {
         query: String,
         #[arg(short = 'n', long, default_value = "10")]
         limit: usize,
+        /// Scope to the subtree rooted at this node id (inclusive).
+        #[arg(long)]
+        under: Option<String>,
     },
     /// Instances of a component (by node id, key, or name).
     Instances { target: String },
@@ -135,6 +159,10 @@ enum Cmd {
         style_type: Option<String>,
         #[arg(long)]
         values: bool,
+        /// With --values, annotate the definition's variable bindings under
+        /// a `resolved_variables` key.
+        #[arg(long)]
+        resolve_vars: bool,
     },
     /// Nodes using a style id or bound to a variable id.
     Uses { id: String },
@@ -150,6 +178,9 @@ enum Cmd {
     Text {
         #[arg(long)]
         page: Option<String>,
+        /// Scope to the subtree rooted at this node id (inclusive).
+        #[arg(long)]
+        under: Option<String>,
     },
     /// Nodes whose raw JSON matches an RFC 6901 pointer, optionally by value.
     Where {
@@ -161,6 +192,9 @@ enum Cmd {
         equals: Option<String>,
         #[arg(long)]
         page: Option<String>,
+        /// Scope to the subtree rooted at this node id (inclusive).
+        #[arg(long)]
+        under: Option<String>,
     },
     /// Nodes whose absolute bounds contain a point, sorted by area ascending.
     At {
@@ -293,14 +327,52 @@ fn dispatch(cli: Cli) -> Result<(), String> {
                 Cmd::Get {
                     id,
                     children: with_children,
-                } => st.rtx(|((nodes, children, ..), ..)| {
-                    read::cmd_get(&nodes, &children, id, with_children)
+                    resolve_vars,
+                } => st.rtx(
+                    |((nodes, children, ..), _, _, _, variables, variable_collections, ..)| {
+                        read::cmd_get(
+                            &nodes,
+                            &children,
+                            &variables,
+                            &variable_collections,
+                            id,
+                            with_children,
+                            resolve_vars,
+                        )
+                    },
+                ),
+                Cmd::Dump {
+                    id,
+                    depth,
+                    fields,
+                    resolve_vars,
+                } => st.rtx(
+                    |((nodes, children, ..), _, _, _, variables, variable_collections, ..)| {
+                        read::cmd_dump(
+                            &nodes,
+                            &children,
+                            &variables,
+                            &variable_collections,
+                            id,
+                            depth,
+                            fields,
+                            resolve_vars,
+                        )
+                    },
+                ),
+                Cmd::Find {
+                    node_type,
+                    page,
+                    under,
+                } => st.rtx(|((nodes, children, _, _, _, _, by_type), ..)| {
+                    read::cmd_find(&nodes, &children, &by_type, node_type, page, under)
                 }),
-                Cmd::Find { node_type, page } => st.rtx(|((nodes, _, _, _, _, _, by_type), ..)| {
-                    read::cmd_find(&nodes, &by_type, node_type, page)
-                }),
-                Cmd::Search { query, limit } => st.rtx(|((nodes, _, text, ..), ..)| {
-                    read::cmd_search(&nodes, &text, query, limit)
+                Cmd::Search {
+                    query,
+                    limit,
+                    under,
+                } => st.rtx(|((nodes, children, text, ..), ..)| {
+                    read::cmd_search(&nodes, &children, &text, query, limit, under)
                 }),
                 Cmd::Instances { target } => st.rtx(
                     |((nodes, _, _, instances_of, ..), components, component_sets, ..)| {
@@ -316,11 +388,32 @@ fn dispatch(cli: Cli) -> Result<(), String> {
                 Cmd::Components => st.rtx(|((nodes, ..), components, component_sets, ..)| {
                     read::cmd_components(&component_sets, &components, &nodes)
                 }),
-                Cmd::Styles { style_type, values } => {
-                    st.rtx(|((nodes, _, _, _, styled_by, ..), _, _, styles, ..)| {
-                        read::cmd_styles(&styles, &styled_by, &nodes, style_type, values)
-                    })
-                }
+                Cmd::Styles {
+                    style_type,
+                    values,
+                    resolve_vars,
+                } => st.rtx(
+                    |(
+                        (nodes, _, _, _, styled_by, ..),
+                        _,
+                        _,
+                        styles,
+                        variables,
+                        variable_collections,
+                        ..,
+                    )| {
+                        read::cmd_styles(
+                            &styles,
+                            &styled_by,
+                            &nodes,
+                            &variables,
+                            &variable_collections,
+                            style_type,
+                            values,
+                            resolve_vars,
+                        )
+                    },
+                ),
                 Cmd::Uses { id } => st.rtx(|((nodes, _, _, _, styled_by, bound_to, _), ..)| {
                     read::cmd_uses(&nodes, &styled_by, &bound_to, id)
                 }),
@@ -349,14 +442,19 @@ fn dispatch(cli: Cli) -> Result<(), String> {
                     },
                 ),
                 Cmd::Path { id } => st.rtx(|((nodes, ..), ..)| read::cmd_path(&nodes, id)),
-                Cmd::Text { page } => st.rtx(|((nodes, _, _, _, _, _, by_type), ..)| {
-                    read::cmd_text(&nodes, &by_type, page)
-                }),
+                Cmd::Text { page, under } => {
+                    st.rtx(|((nodes, children, _, _, _, _, by_type), ..)| {
+                        read::cmd_text(&nodes, &children, &by_type, page, under)
+                    })
+                }
                 Cmd::Where {
                     pointer,
                     equals,
                     page,
-                } => st.rtx(|((nodes, ..), ..)| read::cmd_where(&nodes, pointer, equals, page)),
+                    under,
+                } => st.rtx(|((nodes, children, ..), ..)| {
+                    read::cmd_where(&nodes, &children, pointer, equals, page, under)
+                }),
                 Cmd::At { x, y } => st.rtx(|((nodes, ..), ..)| read::cmd_at(&nodes, x, y)),
                 Cmd::Pull { .. }
                 | Cmd::ImportVariables { .. }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -381,6 +381,7 @@ fn dispatch(cli: Cli) -> Result<(), String> {
         }
     }
 
+    let db_given = cli.db.is_some();
     let db = resolve_db(&cli)?;
     let no_socket = cli.no_socket;
     match cli.cmd {
@@ -396,7 +397,7 @@ fn dispatch(cli: Cli) -> Result<(), String> {
             format,
             scale,
             out,
-        } => images::cmd_images(&db, no_socket, ids, format, scale, out),
+        } => images::cmd_images(&db, no_socket, db_given, ids, format, scale, out),
         Cmd::Call {
             tool,
             args,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,6 +15,7 @@ use serde_json::{Value, json};
 use crate::ident::parse_file_ref;
 
 mod call;
+mod images;
 mod pull;
 mod read;
 mod socket;
@@ -215,6 +216,22 @@ enum Cmd {
         #[arg(long)]
         y: f64,
     },
+    /// Download node renders and/or fill images to --out, caching by file
+    /// version (spec §5). Never automatic — the images endpoints are
+    /// Figma's most rate-limited.
+    Images {
+        /// Node ids (or Figma URLs carrying node-id=) to render, and/or
+        /// scan for fill imageRefs.
+        ids: Vec<String>,
+        #[arg(long, default_value = "png")]
+        format: String,
+        /// Render scale (default 1).
+        #[arg(long)]
+        scale: Option<f64>,
+        /// Output directory (default ./figmog-images/).
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
 }
 
 /// Sentinel [`dispatch`]/[`write_json`] error string meaning "stdout
@@ -364,6 +381,7 @@ fn dispatch(cli: Cli) -> Result<(), String> {
     }
 
     let db = resolve_db(&cli)?;
+    let no_socket = cli.no_socket;
     match cli.cmd {
         Cmd::Pull {
             file,
@@ -372,6 +390,12 @@ fn dispatch(cli: Cli) -> Result<(), String> {
             geometry,
         } => pull::cmd_pull(&db, file, from_file, fresh, geometry),
         Cmd::ImportVariables { path } => call::cmd_import_variables(&db, path),
+        Cmd::Images {
+            ids,
+            format,
+            scale,
+            out,
+        } => images::cmd_images(&db, no_socket, ids, format, scale, out),
         Cmd::Call {
             tool,
             args,
@@ -387,9 +411,11 @@ fn dispatch(cli: Cli) -> Result<(), String> {
             // destructure an unconstrained associated type.
             let st = open_store_checked(|| crate::open_store!(&db.path))?;
             match other {
-                Cmd::Status => st.rtx(|((nodes, _, _, _, _, _, _), _, _, _, _, _, meta, _, _)| {
-                    read::cmd_status(&nodes, &meta)
-                }),
+                Cmd::Status => st.rtx(
+                    |((nodes, _, _, _, _, _, _), _, _, _, _, _, meta, _, _, _)| {
+                        read::cmd_status(&nodes, &meta)
+                    },
+                ),
                 Cmd::Pages => st
                     .rtx(|((nodes, _, _, _, _, _, by_type), ..)| read::cmd_pages(&nodes, &by_type)),
                 Cmd::Tree { id, depth } => {
@@ -491,7 +517,7 @@ fn dispatch(cli: Cli) -> Result<(), String> {
                     read::cmd_uses(&nodes, &styled_by, &bound_to, id)
                 }),
                 Cmd::Vars { id } => st.rtx(
-                    |((nodes, ..), _, _, _, variables, variable_collections, _, _, _)| {
+                    |((nodes, ..), _, _, _, variables, variable_collections, _, _, _, _)| {
                         read::cmd_vars(&nodes, &variables, &variable_collections, id)
                     },
                 ),
@@ -533,7 +559,8 @@ fn dispatch(cli: Cli) -> Result<(), String> {
                 | Cmd::ImportVariables { .. }
                 | Cmd::Serve { .. }
                 | Cmd::Tools { .. }
-                | Cmd::Call { .. } => {
+                | Cmd::Call { .. }
+                | Cmd::Images { .. } => {
                     unreachable!("handled above")
                 }
             }
@@ -719,7 +746,8 @@ fn cmd_as_tool_call(cmd: &Cmd) -> Option<(&'static str, Value)> {
         | Cmd::Serve { .. }
         | Cmd::Tools { .. }
         | Cmd::Call { .. }
-        | Cmd::ImportVariables { .. } => None,
+        | Cmd::ImportVariables { .. }
+        | Cmd::Images { .. } => None,
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -307,6 +307,7 @@ fn dispatch(cli: Cli) -> Result<(), String> {
             && let Some(result) = socket::try_tools_list(Path::new(socket::DEFAULT_ROOT))
         {
             let tools = result?;
+            note_ignored_upstream_flags(upstream, *no_upstream);
             return write_json(&socket::tools_rows(&tools));
         }
         return call::cmd_tools(upstream.clone(), *no_upstream);
@@ -323,20 +324,37 @@ fn dispatch(cli: Cli) -> Result<(), String> {
     // `cli.db` was given, exactly like `--no-socket`.
     if !cli.no_socket && cli.db.is_none() {
         let root = Path::new(socket::DEFAULT_ROOT);
-        if let Cmd::Call { tool, args, .. } = &cli.cmd {
+        if let Cmd::Call {
+            tool,
+            args,
+            upstream,
+            no_upstream,
+        } = &cli.cmd
+        {
             let parsed_args: Value = match args {
                 Some(raw) => {
                     serde_json::from_str(raw).map_err(|e| format!("--args: invalid JSON: {e}"))?
                 }
                 None => json!({}),
             };
+            // C1: route to the current mirror, exactly like direct mode's
+            // own `resolve_db` would — except `figmog_open`, whose `file`
+            // argument means "the file to open", not a routing hint (see
+            // `with_current_file`'s doc comment).
+            let parsed_args = if tool == "figmog_open" {
+                parsed_args
+            } else {
+                with_current_file(parsed_args)
+            };
             if let Some(result) = socket::try_call(root, tool, parsed_args) {
+                note_ignored_upstream_flags(upstream, *no_upstream);
                 return write_json(&result?);
             }
-        } else if let Some((tool, tool_args)) = cmd_as_tool_call(&cli.cmd)
-            && let Some(result) = socket::try_call(root, tool, tool_args)
-        {
-            return write_json(&result?);
+        } else if let Some((tool, tool_args)) = cmd_as_tool_call(&cli.cmd) {
+            let tool_args = with_current_file(strip_nulls(tool_args));
+            if let Some(result) = socket::try_call(root, tool, tool_args) {
+                return write_json(&strip_routed_upstream_field(result?));
+            }
         }
     }
 
@@ -517,6 +535,102 @@ fn dispatch(cli: Cli) -> Result<(), String> {
     }
 }
 
+/// Review m5: when a `tools`/`call` invocation explicitly named an
+/// `--upstream`/`--no-upstream` but got routed to the running serve's own
+/// socket, that flag was silently ignored (serve's own upstream connection,
+/// established at its own startup, is what actually answers — see
+/// `socket::try_tools_list`'s doc comment). Rather than leave that silent,
+/// print one stderr note. Detecting "explicitly passed" without clap's
+/// `ArgMatches` introspection is approximate: `no_upstream` is unambiguous
+/// (there's no way to "explicitly pass false" for a plain flag), but
+/// `upstream` can only be compared against its own default value — a user
+/// who explicitly retyped that exact default URL goes unnoted. An
+/// acceptable, documented gap for an informational note, not a behavior
+/// difference.
+fn note_ignored_upstream_flags(upstream: &str, no_upstream: bool) {
+    if no_upstream || upstream != crate::serve::DEFAULT_UPSTREAM_URL {
+        eprintln!(
+            "figmog: --upstream/--no-upstream ignored — routed to the running serve, whose own upstream settings apply"
+        );
+    }
+}
+
+/// Inject `.figmog/current`'s key as the routed `file` argument, when one
+/// is established and the call doesn't already carry an explicit `file`
+/// (review C1): without this, a socket-routed call carries no `file` at
+/// all, so serve answers from *its own* default session
+/// (`SessionManager::effective_default_key`) — which can silently diverge
+/// from the mirror `.figmog/current` (and thus direct mode) actually
+/// targets, or, in the zero-startup-file quick-start shape, doesn't exist
+/// at all (serve has no sessions yet), producing a hard "no default
+/// mirrored file" error even though a mirror is clearly established on
+/// disk. Injecting the current key routes the call through
+/// `SessionManager::resolve`'s explicit-`file` path instead, which
+/// auto-opens that session if serve hasn't touched it yet — a real
+/// Tier-1 pull only if the on-disk store isn't already mirrored (an
+/// already-pulled store never spends one; see `sessions::open_session_at`'s
+/// `mirrored: meta_present`). `.figmog/current` unset ⇒ args unchanged,
+/// preserving today's serve-own-default behavior exactly.
+///
+/// Never applied to `figmog_open`: unlike every other tool, `figmog_open`'s
+/// own `file` argument names the file *to open*, not a routing hint — it's
+/// required, and direct mode's own dispatch correctly rejects an omitted
+/// one; silently defaulting it here would let `figmog call figmog_open`
+/// (no `--args`) succeed over the socket while the exact same invocation
+/// fails direct, breaking the very byte-compatibility this routing exists
+/// to preserve (see `dispatch::cmd_as_tool_call`'s caller).
+fn with_current_file(mut args: Value) -> Value {
+    if let Some(obj) = args.as_object_mut() {
+        let has_file = obj.get("file").is_some_and(|v| !v.is_null());
+        if !has_file && let Some(key) = read_current_key() {
+            obj.insert("file".to_string(), json!(key));
+        }
+    }
+    args
+}
+
+/// Drop every key whose value is JSON `null` from a routed read command's
+/// argument object (review C2): `json!` always emits a null-valued key for
+/// an absent `Option<T>` field rather than omitting it (e.g.
+/// `cmd_as_tool_call`'s `Cmd::Where` arm always has an `equals` key, `null`
+/// when `--equals` was omitted), but `dispatch_read_tool`'s arg helpers use
+/// *presence*, not truthiness — `figmog_where`'s `equals:
+/// args.get("equals").cloned()` treats a present-but-null `equals` as
+/// "match literal null" rather than "no filter", silently returning zero
+/// rows for the common no-`--equals` case over the socket while direct
+/// mode returns every row with that pointer present. Applied once,
+/// generically, to every `cmd_as_tool_call` translation — rather than
+/// hand-rolling conditional insertion in each match arm — so this class of
+/// bug can't recur as new routed commands are added. (One accepted
+/// imprecision: `--equals null` explicitly, an obscure invocation, is now
+/// indistinguishable from omitting `--equals` entirely, since both encode
+/// as a null-valued key before this strip runs either way — direct mode
+/// keeps the finer distinction via `Option<Value>` at the Rust level.)
+fn strip_nulls(mut args: Value) -> Value {
+    if let Some(obj) = args.as_object_mut() {
+        obj.retain(|_, v| !v.is_null());
+    }
+    args
+}
+
+/// Strip the server-spliced `upstream` field from a routed *read command's*
+/// result (review m1): `upstream` is only ever added inside
+/// `dispatch_read_tool`/`handle_tool_call` — the `figmog_status` *tool*'s
+/// own behavior, which the plain `figmog status` read command has never
+/// gone through (`read::cmd_status` calls `query::status` directly, with
+/// no splice at all) — so leaving it in a socket-routed `status` would
+/// make the two modes diverge on this one field even after every other fix
+/// here. A no-op for every other command's result, none of which carry
+/// this key. (`figmog call figmog_status` is unaffected: both modes go
+/// through `dispatch_read_tool` there, so both already carry `upstream`
+/// consistently — this strip is not applied to `Cmd::Call`.)
+fn strip_routed_upstream_field(mut result: Value) -> Value {
+    if let Some(obj) = result.as_object_mut() {
+        obj.remove("upstream");
+    }
+    result
+}
+
 /// Maps a read-only [`Cmd`] to the equivalent local `figmog_*` tool name +
 /// arguments `figmog serve` would answer over the socket (spec §1's CLI
 /// routing) — the exact argument shapes [`crate::dispatch::dispatch_read_tool`]
@@ -634,17 +748,26 @@ fn resolve_db(cli: &Cli) -> Result<Db, String> {
         });
     }
 
-    let key = std::fs::read_to_string(CURRENT_FILE)
-        .map_err(|_| no_mirror_msg(cli))?
-        .trim()
-        .to_string();
-    if key.is_empty() {
-        return Err(no_mirror_msg(cli));
-    }
+    let key = read_current_key().ok_or_else(|| no_mirror_msg(cli))?;
     Ok(Db {
         path: db_path_for(&key),
         key: Some(key),
     })
+}
+
+/// Best-effort read of `.figmog/current` — `None` on any I/O error or an
+/// empty file (the same "no established mirror" cases [`resolve_db`]
+/// turns into an error; socket routing instead treats `None` as "let
+/// serve's own default apply, unchanged" — see [`with_current_file`]).
+/// Shared so both call sites derive the current mirror identically.
+fn read_current_key() -> Option<String> {
+    let key = std::fs::read_to_string(CURRENT_FILE).ok()?;
+    let key = key.trim();
+    if key.is_empty() {
+        None
+    } else {
+        Some(key.to_string())
+    }
 }
 
 /// `pull --from-file` with neither a file ref nor an established key has
@@ -802,5 +925,52 @@ mod tests {
 
         let other_payload: Box<dyn std::any::Any + Send> = Box::new(42i32);
         assert_eq!(panic_message(&*other_payload), "unknown panic");
+    }
+
+    // ---- socket-routing helpers (review C1/C2/m1 fix round) ----
+
+    #[test]
+    fn strip_nulls_drops_null_keys_and_keeps_everything_else() {
+        let args = strip_nulls(json!({
+            "pointer": "/layoutMode",
+            "equals": null,
+            "page": null,
+            "under": "1:1",
+            "limit": 0,
+        }));
+        assert_eq!(
+            args,
+            json!({"pointer": "/layoutMode", "under": "1:1", "limit": 0})
+        );
+    }
+
+    #[test]
+    fn strip_nulls_is_a_no_op_on_an_object_with_no_nulls() {
+        let args = json!({"id": "1:1", "children": true});
+        assert_eq!(strip_nulls(args.clone()), args);
+    }
+
+    #[test]
+    fn strip_routed_upstream_field_removes_only_that_key() {
+        let result = strip_routed_upstream_field(json!({
+            "name": "Fixture",
+            "nodes": 12,
+            "upstream": "connected",
+        }));
+        assert_eq!(result, json!({"name": "Fixture", "nodes": 12}));
+    }
+
+    #[test]
+    fn strip_routed_upstream_field_is_a_no_op_when_absent() {
+        let result = json!({"name": "Fixture", "nodes": 12});
+        assert_eq!(strip_routed_upstream_field(result.clone()), result);
+    }
+
+    #[test]
+    fn with_current_file_never_overrides_an_explicit_non_null_file() {
+        // No filesystem dependency either way: an explicit `file` short-
+        // circuits before `read_current_key` is ever consulted.
+        let args = with_current_file(json!({"id": "1:1", "file": "explicitkey12345678"}));
+        assert_eq!(args["file"], json!("explicitkey12345678"));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -221,7 +221,8 @@ enum Cmd {
     /// Figma's most rate-limited.
     Images {
         /// Node ids (or Figma URLs carrying node-id=) to render, and/or
-        /// scan for fill imageRefs.
+        /// scan for fill imageRefs. At least one required.
+        #[arg(required = true)]
         ids: Vec<String>,
         #[arg(long, default_value = "png")]
         format: String,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,7 @@
 //! keeps the clap types, top-level dispatch, `run`, and the store-opening/
 //! JSON-writing helpers every submodule shares.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
 use serde_json::{Value, json};
@@ -17,6 +17,7 @@ use crate::ident::parse_file_ref;
 mod call;
 mod pull;
 mod read;
+mod socket;
 
 pub(crate) use pull::{PullError, now_ms, pull_failure_wait, write_current};
 
@@ -26,6 +27,12 @@ struct Cli {
     /// Store directory (default: .figmog/<file-key>/db).
     #[arg(long, global = true)]
     db: Option<PathBuf>,
+    /// Don't try the running serve's unix-socket control plane (spec §1):
+    /// every read command, `tools`, and `call` always open the store
+    /// directly, exactly like pre-v0.0.2 figmog. On `figmog serve`, don't
+    /// listen on the socket at all.
+    #[arg(long, global = true)]
+    no_socket: bool,
     #[command(subcommand)]
     cmd: Cmd,
 }
@@ -275,6 +282,7 @@ fn dispatch(cli: Cli) -> Result<(), String> {
             upstream.clone(),
             *no_upstream,
             figmog_root.clone(),
+            cli.no_socket,
         );
     }
 
@@ -283,12 +291,53 @@ fn dispatch(cli: Cli) -> Result<(), String> {
     // `resolve_db`, exactly like `serve` above: it works with no
     // established `.figmog/current` and no `--db` at all, unlike `figmog
     // call` (below), which does need a resolved mirror to open.
+    //
+    // Socket routing (spec §1) applies here too, before any direct probe:
+    // reachable ⇒ the *running serve's* own merged registry (its own
+    // upstream connection, not this invocation's `--upstream`/
+    // `--no-upstream` — see `socket::try_tools_list`'s doc comment)
+    // answers instead.
     if let Cmd::Tools {
         upstream,
         no_upstream,
     } = &cli.cmd
     {
+        if !cli.no_socket
+            && cli.db.is_none()
+            && let Some(result) = socket::try_tools_list(Path::new(socket::DEFAULT_ROOT))
+        {
+            let tools = result?;
+            return write_json(&socket::tools_rows(&tools));
+        }
         return call::cmd_tools(upstream.clone(), *no_upstream);
+    }
+
+    // Socket routing (spec §1): every read command plus `call` first tries
+    // the running serve's unix-socket control plane for the resolved
+    // figmog-root — reachable ⇒ the command becomes a client of serve
+    // (always-fresh, no lock, and `call figmog_sync` reaches the *owning*
+    // process); unreachable ⇒ falls through to the direct-open path below,
+    // unchanged. Only meaningful when the root is knowable at all: `--db`
+    // bypasses the whole multi-file root concept (an arbitrary store path
+    // has no `<root>/serve.sock` to speak of), so this is skipped whenever
+    // `cli.db` was given, exactly like `--no-socket`.
+    if !cli.no_socket && cli.db.is_none() {
+        let root = Path::new(socket::DEFAULT_ROOT);
+        if let Cmd::Call { tool, args, .. } = &cli.cmd {
+            let parsed_args: Value = match args {
+                Some(raw) => {
+                    serde_json::from_str(raw).map_err(|e| format!("--args: invalid JSON: {e}"))?
+                }
+                None => json!({}),
+            };
+            if let Some(result) = socket::try_call(root, tool, parsed_args) {
+                return write_json(&result?);
+            }
+        } else if let Some((tool, tool_args)) = cmd_as_tool_call(&cli.cmd)
+            && let Some(result) = socket::try_call(root, tool, tool_args)
+        {
+            return write_json(&result?);
+        }
     }
 
     let db = resolve_db(&cli)?;
@@ -465,6 +514,92 @@ fn dispatch(cli: Cli) -> Result<(), String> {
                 }
             }
         }
+    }
+}
+
+/// Maps a read-only [`Cmd`] to the equivalent local `figmog_*` tool name +
+/// arguments `figmog serve` would answer over the socket (spec §1's CLI
+/// routing) — the exact argument shapes [`crate::dispatch::dispatch_read_tool`]
+/// expects, so a socket-routed read produces byte-identical results to the
+/// direct-open path below. `None` for every command socket routing doesn't
+/// apply to: `pull` is a writer (spec §1: "pull stays direct-open");
+/// `serve`/`tools`/`call`/`import-variables` are each handled at their own
+/// call sites (`serve`/`tools` before this is ever reached, `call` by
+/// `dispatch`'s own socket block above `import-variables` is a writer, like
+/// `pull`, and isn't part of spec §1's routed surface at all).
+fn cmd_as_tool_call(cmd: &Cmd) -> Option<(&'static str, Value)> {
+    match cmd {
+        Cmd::Status => Some(("figmog_status", json!({}))),
+        Cmd::Pages => Some(("figmog_pages", json!({}))),
+        Cmd::Tree { id, depth } => Some(("figmog_tree", json!({"id": id, "depth": depth}))),
+        Cmd::Get {
+            id,
+            children,
+            resolve_vars,
+        } => Some((
+            "figmog_node",
+            json!({"id": id, "children": children, "resolve_vars": resolve_vars}),
+        )),
+        Cmd::Dump {
+            id,
+            depth,
+            fields,
+            resolve_vars,
+        } => Some((
+            "figmog_subtree",
+            json!({"id": id, "depth": depth, "fields": fields, "resolve_vars": resolve_vars}),
+        )),
+        Cmd::Find {
+            node_type,
+            page,
+            under,
+        } => Some((
+            "figmog_find",
+            json!({"type": node_type, "page": page, "under": under}),
+        )),
+        Cmd::Search {
+            query,
+            limit,
+            under,
+        } => Some((
+            "figmog_search",
+            json!({"query": query, "limit": limit, "under": under}),
+        )),
+        Cmd::Instances { target } => Some(("figmog_instances", json!({"target": target}))),
+        Cmd::Components => Some(("figmog_components", json!({}))),
+        Cmd::Styles {
+            style_type,
+            values,
+            resolve_vars,
+        } => Some((
+            "figmog_styles",
+            json!({"type": style_type, "values": values, "resolve_vars": resolve_vars}),
+        )),
+        Cmd::Uses { id } => Some(("figmog_uses", json!({"id": id}))),
+        Cmd::Vars { id } => Some(("figmog_vars", json!({"id": id}))),
+        Cmd::Stats => Some(("figmog_stats", json!({}))),
+        Cmd::Path { id } => Some(("figmog_path", json!({"id": id}))),
+        Cmd::Text { page, under } => Some(("figmog_text", json!({"page": page, "under": under}))),
+        Cmd::Where {
+            pointer,
+            equals,
+            page,
+            under,
+        } => Some((
+            "figmog_where",
+            json!({
+                "pointer": pointer,
+                "equals": equals.as_deref().map(read::parse_equals),
+                "page": page,
+                "under": under,
+            }),
+        )),
+        Cmd::At { x, y } => Some(("figmog_at", json!({"x": x, "y": y}))),
+        Cmd::Pull { .. }
+        | Cmd::Serve { .. }
+        | Cmd::Tools { .. }
+        | Cmd::Call { .. }
+        | Cmd::ImportVariables { .. } => None,
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -49,6 +49,11 @@ enum Cmd {
         /// Wipe the store and rebuild from scratch.
         #[arg(long)]
         fresh: bool,
+        /// Request vector path data (fillGeometry/strokeGeometry) on this
+        /// pull. Sticky (spec §4): once set, every later pull of this
+        /// mirror keeps requesting it until `--fresh`.
+        #[arg(long)]
+        geometry: bool,
     },
     /// MCP stdio server: `figmog_*` tools over the local mirror, with the
     /// sync loop built in (one process owns the store), plus (unless
@@ -364,7 +369,8 @@ fn dispatch(cli: Cli) -> Result<(), String> {
             file,
             from_file,
             fresh,
-        } => pull::cmd_pull(&db, file, from_file, fresh),
+            geometry,
+        } => pull::cmd_pull(&db, file, from_file, fresh, geometry),
         Cmd::ImportVariables { path } => call::cmd_import_variables(&db, path),
         Cmd::Call {
             tool,
@@ -381,7 +387,7 @@ fn dispatch(cli: Cli) -> Result<(), String> {
             // destructure an unconstrained associated type.
             let st = open_store_checked(|| crate::open_store!(&db.path))?;
             match other {
-                Cmd::Status => st.rtx(|((nodes, _, _, _, _, _, _), _, _, _, _, _, meta, _)| {
+                Cmd::Status => st.rtx(|((nodes, _, _, _, _, _, _), _, _, _, _, _, meta, _, _)| {
                     read::cmd_status(&nodes, &meta)
                 }),
                 Cmd::Pages => st
@@ -485,7 +491,7 @@ fn dispatch(cli: Cli) -> Result<(), String> {
                     read::cmd_uses(&nodes, &styled_by, &bound_to, id)
                 }),
                 Cmd::Vars { id } => st.rtx(
-                    |((nodes, ..), _, _, _, variables, variable_collections, _, _)| {
+                    |((nodes, ..), _, _, _, variables, variable_collections, _, _, _)| {
                         read::cmd_vars(&nodes, &variables, &variable_collections, id)
                     },
                 ),

--- a/src/cli/pull.rs
+++ b/src/cli/pull.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use crate::api::{ApiError, FigmaApi, UreqApi};
 use crate::flatten::flatten_file;
 use crate::ident::parse_file_ref;
-use crate::store::{Churn, collect_sweepable, collect_variable_ids, sync};
+use crate::store::{self, Churn, collect_sweepable, collect_variable_ids, sync};
 use crate::watch::BACKOFF_CAP;
 
 use super::{CURRENT_FILE, Db, open_store_checked, write_json};
@@ -39,8 +39,9 @@ pub(super) fn cmd_pull(
     file: Option<String>,
     from_file: Option<PathBuf>,
     fresh: bool,
+    geometry: bool,
 ) -> Result<(), String> {
-    let (churn, _name, _version) = do_pull(db, file, from_file, fresh).map_err(|e| {
+    let (churn, _name, _version) = do_pull(db, file, from_file, fresh, geometry).map_err(|e| {
         let message = e.to_string();
         // `pull` is a writer (spec §1: it stays direct-open, never routed
         // over the socket), so a running `figmog serve` holding the same
@@ -64,11 +65,21 @@ pub(super) fn cmd_pull(
 /// The pull mechanics without any printing. `.figmog/current` is written
 /// only once the sync below has actually happened, so a failed pull never
 /// repoints later commands at a nonexistent mirror.
+///
+/// `geometry` is this call's own override (spec §4 stickiness): the
+/// network fetch requests `?geometry=paths` when `geometry` is set *or*
+/// the mirror's already-stored config has it on
+/// (`store::effective_geometry`); the resulting flag is persisted back via
+/// `store::upsert_mirror_config` regardless of path, so it survives to
+/// drive the next pull even for `--from-file` (which never touches the
+/// network, and so never reads this flag for a fetch parameter at all —
+/// see the `from_file` match arm below).
 pub(super) fn do_pull(
     db: &Db,
     file: Option<String>,
     from_file: Option<PathBuf>,
     fresh: bool,
+    geometry: bool,
 ) -> Result<(Churn, String, String), PullError> {
     // `vars_resp` is only ever `Some` on the network path — `--from-file`
     // ingests a saved `GET /v1/files/:key` response and never touches the
@@ -89,8 +100,29 @@ pub(super) fn do_pull(
                 .ok_or_else(|| "no file key: pass a file key or figma.com URL".to_string())?;
             let token = std::env::var("FIGMA_TOKEN")
                 .map_err(|_| "FIGMA_TOKEN not set — required for network pulls".to_string())?;
+            // Peek the mirror's stored geometry setting (spec §4) *before*
+            // fetching, so a plain re-pull of a mirror that was ever
+            // pulled with `--geometry` keeps asking for it. `--fresh`
+            // wipes the store below and never consults it (the documented
+            // way to turn geometry back off), so this never opens a store
+            // that's about to be discarded — and a first-ever pull (no
+            // store on disk yet) never opens one at all, so a token
+            // failure above still leaves no store trace (unchanged from
+            // pre-v0.0.2 — see `failed_pull_does_not_persist_current_or_
+            // create_store`). When a store does exist, this is a second,
+            // short-lived open dropped before the real one further down —
+            // fjall allows only one open handle per store per process at a
+            // time, not one ever; dropping releases its lock.
+            let stored_geometry = if fresh || !db.path.exists() {
+                false
+            } else {
+                open_store_checked(|| crate::open_store!(&db.path))
+                    .map(|st| st.rtx(|(.., mirror_config)| store::read_geometry(&mirror_config)))
+                    .unwrap_or(false)
+            };
+            let request_geometry = store::effective_geometry(geometry, stored_geometry);
             let api = UreqApi::new(token);
-            let resp = api.file(&key)?;
+            let resp = api.file(&key, request_geometry)?;
             // Opportunistic Enterprise variables sync (spec §12): `Ok(None)`
             // on non-Enterprise plans is not an error — v1 behavior
             // (import/inference, sweep-exempt) holds unchanged below.
@@ -113,13 +145,13 @@ pub(super) fn do_pull(
     if let Some(v) = &vars_resp {
         let var_recs = crate::vars::parse_variables_export(v).map_err(|e| e.to_string())?;
         flattened.recs.extend(var_recs);
-        let stored_var_ids = st.rtx(|(_, _, _, _, variables, variable_collections, _, _)| {
+        let stored_var_ids = st.rtx(|(_, _, _, _, variables, variable_collections, _, _, _)| {
             collect_variable_ids(&variables, &variable_collections)
         });
         prior.extend(stored_var_ids);
     }
     let prior_version =
-        st.rtx(|(_, _, _, _, _, _, meta, _)| meta.get(&0).map(|m| m.version.clone()));
+        st.rtx(|(_, _, _, _, _, _, meta, _, _)| meta.get(&0).map(|m| m.version.clone()));
     let churn = sync(&mut st, &prior, &flattened, now_ms());
 
     // Every caller of `do_pull` (`pull` and `figmog call figmog_sync`) goes
@@ -131,13 +163,25 @@ pub(super) fn do_pull(
     // re-opening it here would hit the same single-open-per-process wall
     // `figmog call figmog_sync` used to.
     if prior_version.as_deref() != Some(flattened.file.version.as_str()) {
-        let stale = st.rtx(|(_, _, _, _, _, _, _, cache)| {
+        let stale = st.rtx(|(_, _, _, _, _, _, _, cache, _)| {
             crate::store::stale_cache_ids(&cache, &flattened.file.version)
         });
         if !stale.is_empty() {
             crate::store::evict_stale_cache(&mut st, &stale);
         }
     }
+
+    // Persist the sticky geometry flag (spec §4): this call's own flag OR
+    // whatever's already stored in *this* handle (re-read here rather than
+    // reusing `stored_geometry` above — that value came from a separate,
+    // now-dropped peek on the network path, and doesn't exist at all on
+    // the `--from-file` path, which still must persist stickiness even
+    // though it never requested anything over the network — see this
+    // function's doc comment). `--fresh` already wiped any prior row, so
+    // this store's own current read is `false` there, giving exactly
+    // `geometry` as the persisted value, same as the fetch decision above.
+    let stored_now = st.rtx(|(.., mirror_config)| store::read_geometry(&mirror_config));
+    store::upsert_mirror_config(&mut st, store::effective_geometry(geometry, stored_now));
 
     if let Some(key) = &db.key {
         write_current(key)?;

--- a/src/cli/pull.rs
+++ b/src/cli/pull.rs
@@ -40,8 +40,24 @@ pub(super) fn cmd_pull(
     from_file: Option<PathBuf>,
     fresh: bool,
 ) -> Result<(), String> {
-    let (churn, _name, _version) =
-        do_pull(db, file, from_file, fresh).map_err(|e| e.to_string())?;
+    let (churn, _name, _version) = do_pull(db, file, from_file, fresh).map_err(|e| {
+        let message = e.to_string();
+        // `pull` is a writer (spec §1: it stays direct-open, never routed
+        // over the socket), so a running `figmog serve` holding the same
+        // store's single-writer lock is the single most common way this
+        // fails while serve is up — point at the one escape hatch that
+        // still works in that situation (`figmog call figmog_sync` reaches
+        // the *owning* process over the socket) rather than leaving the
+        // generic "is figmog serve running?" message to speak for itself.
+        // Scoped to exactly this message (not every `do_pull` failure) so
+        // an unrelated error (bad JSON, a real network failure, ...) isn't
+        // given a hint that doesn't apply to it.
+        if message == super::STORE_LOCKED_MSG {
+            format!("{message} — or ask the running serve: figmog call figmog_sync")
+        } else {
+            message
+        }
+    })?;
     print_churn(&churn)
 }
 

--- a/src/cli/pull.rs
+++ b/src/cli/pull.rs
@@ -117,7 +117,7 @@ pub(super) fn do_pull(
                 false
             } else {
                 open_store_checked(|| crate::open_store!(&db.path))
-                    .map(|st| st.rtx(|(.., mirror_config)| store::read_geometry(&mirror_config)))
+                    .map(|st| st.rtx(|(.., mirror_config, _)| store::read_geometry(&mirror_config)))
                     .unwrap_or(false)
             };
             let request_geometry = store::effective_geometry(geometry, stored_geometry);
@@ -145,28 +145,37 @@ pub(super) fn do_pull(
     if let Some(v) = &vars_resp {
         let var_recs = crate::vars::parse_variables_export(v).map_err(|e| e.to_string())?;
         flattened.recs.extend(var_recs);
-        let stored_var_ids = st.rtx(|(_, _, _, _, variables, variable_collections, _, _, _)| {
-            collect_variable_ids(&variables, &variable_collections)
-        });
+        let stored_var_ids = st.rtx(
+            |(_, _, _, _, variables, variable_collections, _, _, _, _)| {
+                collect_variable_ids(&variables, &variable_collections)
+            },
+        );
         prior.extend(stored_var_ids);
     }
     let prior_version =
-        st.rtx(|(_, _, _, _, _, _, meta, _, _)| meta.get(&0).map(|m| m.version.clone()));
+        st.rtx(|(_, _, _, _, _, _, meta, _, _, _)| meta.get(&0).map(|m| m.version.clone()));
     let churn = sync(&mut st, &prior, &flattened, now_ms());
 
     // Every caller of `do_pull` (`pull` and `figmog call figmog_sync`) goes
     // through here, so eviction lives here rather than duplicated at each
     // call site (build design §12: a
-    // version-changing pull sweeps stale `proxy_cache` rows). `figmog
-    // serve`'s own pull paths don't call `do_pull` — they keep their own
-    // inline eviction blocks, since they already hold `st` open and
-    // re-opening it here would hit the same single-open-per-process wall
-    // `figmog call figmog_sync` used to.
+    // version-changing pull sweeps stale `proxy_cache` rows; v0.0.2 spec §5
+    // extends this to stale `images` rows the same way). `figmog serve`'s
+    // own pull paths don't call `do_pull` — they keep their own inline
+    // eviction blocks, since they already hold `st` open and re-opening it
+    // here would hit the same single-open-per-process wall `figmog call
+    // figmog_sync` used to.
     if prior_version.as_deref() != Some(flattened.file.version.as_str()) {
-        let stale = st.rtx(|(_, _, _, _, _, _, _, cache, _)| {
-            crate::store::stale_cache_ids(&cache, &flattened.file.version)
+        let mut stale = st.rtx(|(_, _, _, _, _, _, _, cache, _, images)| {
+            let mut stale = crate::store::stale_cache_ids(&cache, &flattened.file.version);
+            stale.extend(crate::store::stale_image_ids(
+                &images,
+                &flattened.file.version,
+            ));
+            stale
         });
         if !stale.is_empty() {
+            stale.sort();
             crate::store::evict_stale_cache(&mut st, &stale);
         }
     }
@@ -180,7 +189,7 @@ pub(super) fn do_pull(
     // function's doc comment). `--fresh` already wiped any prior row, so
     // this store's own current read is `false` there, giving exactly
     // `geometry` as the persisted value, same as the fetch decision above.
-    let stored_now = st.rtx(|(.., mirror_config)| store::read_geometry(&mirror_config));
+    let stored_now = st.rtx(|(.., mirror_config, _)| store::read_geometry(&mirror_config));
     store::upsert_mirror_config(&mut st, store::effective_geometry(geometry, stored_now));
 
     if let Some(key) = &db.key {

--- a/src/cli/read.rs
+++ b/src/cli/read.rs
@@ -45,33 +45,74 @@ pub(super) fn cmd_tree<R: Readable>(
     print_value(&query::tree(nodes, children, by_type, id, depth)?)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn cmd_get<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
     children: &MultimapReader<'_, R, String, (u32, String)>,
+    variables: &TableReader<'_, R, String, VariableRec>,
+    variable_collections: &TableReader<'_, R, String, VariableCollectionRec>,
     id: String,
     with_children: bool,
+    resolve_vars: bool,
 ) -> Result<(), String> {
-    print_value(&query::node(nodes, children, id, with_children)?)
+    print_value(&query::node(
+        nodes,
+        children,
+        variables,
+        variable_collections,
+        id,
+        with_children,
+        resolve_vars,
+    )?)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn cmd_dump<R: Readable>(
+    nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
+    variables: &TableReader<'_, R, String, VariableRec>,
+    variable_collections: &TableReader<'_, R, String, VariableCollectionRec>,
+    id: String,
+    depth: Option<usize>,
+    fields: Option<Vec<String>>,
+    resolve_vars: bool,
+) -> Result<(), String> {
+    print_value(&query::subtree(
+        nodes,
+        children,
+        variables,
+        variable_collections,
+        id,
+        depth,
+        fields.as_deref(),
+        resolve_vars,
+    )?)
 }
 
 pub(super) fn cmd_find<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
     by_type: &InvertedIndexReader<'_, R, String, String>,
     node_type: String,
     page: Option<String>,
+    under: Option<String>,
 ) -> Result<(), String> {
-    print_value(&query::find(nodes, by_type, node_type, page)?)
+    print_value(&query::find(
+        nodes, children, by_type, node_type, page, under,
+    )?)
 }
 
 // ---- design-system reads ----
 
 pub(super) fn cmd_search<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
     text: &TextReader<'_, R>,
     query: String,
     limit: usize,
+    under: Option<String>,
 ) -> Result<(), String> {
-    print_value(&query::search(text, nodes, &query, limit)?)
+    print_value(&query::search(text, nodes, children, &query, limit, under)?)
 }
 
 pub(super) fn cmd_instances<R: Readable>(
@@ -98,15 +139,26 @@ pub(super) fn cmd_components<R: Readable>(
     print_value(&query::components(nodes, components, component_sets)?)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn cmd_styles<R: Readable>(
     styles: &TableReader<'_, R, String, StyleRec>,
     styled_by: &InvertedIndexReader<'_, R, String, String>,
     nodes: &TableReader<'_, R, String, NodeRec>,
+    variables: &TableReader<'_, R, String, VariableRec>,
+    variable_collections: &TableReader<'_, R, String, VariableCollectionRec>,
     style_type: Option<String>,
     values: bool,
+    resolve_vars: bool,
 ) -> Result<(), String> {
     print_value(&query::styles(
-        nodes, styles, styled_by, style_type, values,
+        nodes,
+        styles,
+        styled_by,
+        variables,
+        variable_collections,
+        style_type,
+        values,
+        resolve_vars,
     )?)
 }
 
@@ -163,20 +215,27 @@ pub(super) fn cmd_path<R: Readable>(
 
 pub(super) fn cmd_text<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
     by_type: &InvertedIndexReader<'_, R, String, String>,
     page: Option<String>,
+    under: Option<String>,
 ) -> Result<(), String> {
-    print_value(&query::text(nodes, by_type, page)?)
+    print_value(&query::text(nodes, children, by_type, page, under)?)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn cmd_where<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
     pointer: String,
     equals: Option<String>,
     page: Option<String>,
+    under: Option<String>,
 ) -> Result<(), String> {
     let equals = equals.as_deref().map(parse_equals);
-    print_value(&query::where_(nodes, &pointer, equals, page)?)
+    print_value(&query::where_(
+        nodes, children, &pointer, equals, page, under,
+    )?)
 }
 
 pub(super) fn cmd_at<R: Readable>(

--- a/src/cli/read.rs
+++ b/src/cli/read.rs
@@ -183,8 +183,11 @@ pub(super) fn cmd_vars<R: Readable>(
 // ---- whole-file structural queries ----
 
 /// `--equals <json>`: parse as JSON, falling back to treating the bare word
-/// as a JSON string (so `--equals VERTICAL` works without quoting).
-fn parse_equals(raw: &str) -> Value {
+/// as a JSON string (so `--equals VERTICAL` works without quoting). `pub(super)`
+/// so `super::cmd_as_tool_call` (spec §1's socket routing) can build a
+/// `figmog_where` call's `equals` argument identically to this module's own
+/// `cmd_where`.
+pub(super) fn parse_equals(raw: &str) -> Value {
     serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.to_string()))
 }
 

--- a/src/cli/socket.rs
+++ b/src/cli/socket.rs
@@ -133,9 +133,24 @@ fn send_and_recv(stream: UnixStream, frame: &Value) -> Result<Value, String> {
 
     let mut reader = BufReader::new(stream);
     let mut line = String::new();
-    let n = reader
-        .read_line(&mut line)
-        .map_err(|e| format!("reading from serve socket: {e}"))?;
+    let n = reader.read_line(&mut line).map_err(|e| {
+        // Review m2: a timed-out read (the timeout set above) reads as a
+        // generic OS error otherwise (`"Resource temporarily unavailable"`
+        // or similar, depending on platform) — spell out what actually
+        // happened and the escape hatch, rather than leaving the operator
+        // to guess.
+        if matches!(
+            e.kind(),
+            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+        ) {
+            format!(
+                "figmog serve did not respond within {}s (is it wedged? try --no-socket)",
+                SOCKET_TIMEOUT.as_secs()
+            )
+        } else {
+            format!("reading from serve socket: {e}")
+        }
+    })?;
     if n == 0 {
         return Err("serve socket closed before responding".to_string());
     }

--- a/src/cli/socket.rs
+++ b/src/cli/socket.rs
@@ -84,6 +84,34 @@ pub(super) fn tools_rows(tools: &[Value]) -> Value {
     Value::Array(rows)
 }
 
+/// Like [`try_call`], but for `figmog_images` specifically (v0.0.2 spec
+/// §5): returns the raw MCP `result` object (`{"content": [...],
+/// "isError": ...}`) rather than [`interpret_call_response`]'s unwrapped
+/// domain `Value`. `figmog_images`'s content mixes a text manifest block
+/// with `image` (base64) blocks — `interpret_call_response`'s "parse
+/// `content[0]`'s text as figmog's own JSON" contract only fits the
+/// single-text-block shape every other local tool returns, so
+/// `cli::images` (the only caller) needs the whole array to decode the
+/// image blocks and write files itself.
+pub(super) fn try_images_call(root: &Path, args: Value) -> Option<Result<Value, String>> {
+    let stream = UnixStream::connect(socket_path(root)).ok()?;
+    let resp = send_and_recv(
+        stream,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "figmog_images", "arguments": args},
+        }),
+    );
+    Some(resp.and_then(|resp| {
+        if let Some(err) = resp.get("error") {
+            return Err(protocol_error_message(err));
+        }
+        Ok(resp.get("result").cloned().unwrap_or(Value::Null))
+    }))
+}
+
 fn call_over(stream: UnixStream, tool: &str, args: Value) -> Result<Value, String> {
     let resp = send_and_recv(
         stream,

--- a/src/cli/socket.rs
+++ b/src/cli/socket.rs
@@ -88,11 +88,13 @@ pub(super) fn tools_rows(tools: &[Value]) -> Value {
 /// §5): returns the raw MCP `result` object (`{"content": [...],
 /// "isError": ...}`) rather than [`interpret_call_response`]'s unwrapped
 /// domain `Value`. `figmog_images`'s content mixes a text manifest block
-/// with `image` (base64) blocks — `interpret_call_response`'s "parse
-/// `content[0]`'s text as figmog's own JSON" contract only fits the
-/// single-text-block shape every other local tool returns, so
-/// `cli::images` (the only caller) needs the whole array to decode the
-/// image blocks and write files itself.
+/// with per-item payload blocks — `image` (base64, raster formats) or
+/// `text` (raw markup, SVG — see `images::to_mcp_content`'s own doc
+/// comment) — `interpret_call_response`'s "parse `content[0]`'s text as
+/// figmog's own JSON" contract only fits the single-text-block shape
+/// every other local tool returns, so `cli::images` (the only caller)
+/// needs the whole array to decode the payload blocks and write files
+/// itself.
 pub(super) fn try_images_call(root: &Path, args: Value) -> Option<Result<Value, String>> {
     let stream = UnixStream::connect(socket_path(root)).ok()?;
     let resp = send_and_recv(

--- a/src/cli/socket.rs
+++ b/src/cli/socket.rs
@@ -1,0 +1,262 @@
+//! Unix-socket control-plane client (spec §1): every read command, `tools`,
+//! and `call` become clients of a running `figmog serve` process reachable
+//! at `<figmog-root>/serve.sock`, instead of opening the store directly —
+//! always-fresh answers, no single-writer lock contention, and (for `call
+//! figmog_sync`) a pull that reaches the *owning* process rather than
+//! failing against a store `serve` already holds locked.
+//!
+//! Socket routing only applies when the root is knowable at all: `--db`
+//! bypasses the whole multi-file root concept (an arbitrary store path has
+//! no `<root>/serve.sock` to speak of), so callers in `super::dispatch`
+//! only reach this module when `cli.db.is_none()`. [`DEFAULT_ROOT`] is the
+//! CLI's own root — it has no `--figmog-root` override (that's `serve`'s
+//! hidden testability knob only), so this constant must match
+//! [`crate::serve`]'s own default figmog-root exactly for socket routing to
+//! ever find the right process.
+//!
+//! Every function here returns `None` (not `Some(Err(..))`) for "no serve
+//! reachable at this root" — a plain connection failure — so the caller
+//! falls back to a direct store open exactly as if the socket didn't
+//! exist. Once a connection succeeds, `Some(Ok(_))`/`Some(Err(_))` is
+//! authoritative: the call reached serve and the caller must not also
+//! attempt a direct open (spec §1: "Socket reachable ⇒ the command becomes
+//! a client of serve").
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+/// The CLI's multi-file root when `--db` was not passed — always `.figmog`
+/// relative to the current directory, matching `crate::serve::run_serve`'s
+/// own `--figmog-root` default (see this module's doc comment).
+pub(super) const DEFAULT_ROOT: &str = ".figmog";
+
+/// `<root>/serve.sock` — must match [`crate::serve::socket_path`] exactly.
+fn socket_path(root: &Path) -> PathBuf {
+    root.join("serve.sock")
+}
+
+/// A running serve answers a `tools/call` against its own already-open
+/// store near-instantly; anything slower means something's wrong (a
+/// wedged process, a huge query) and the CLI should time out rather than
+/// hang indefinitely.
+const SOCKET_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Send one `tools/call` for `tool`/`args` over `<root>/serve.sock` and
+/// translate the response into the same `Result<Value, String>` shape
+/// every direct-mode command already returns (spec §1: "same JSON on
+/// stdout, same error shapes"). See this module's doc comment for the
+/// `None` vs `Some` contract.
+pub(super) fn try_call(root: &Path, tool: &str, args: Value) -> Option<Result<Value, String>> {
+    let stream = UnixStream::connect(socket_path(root)).ok()?;
+    Some(call_over(stream, tool, args))
+}
+
+/// Like [`try_call`], but for `tools/list` — used by `figmog tools`'s own
+/// socket routing to report the exact merged registry the running serve
+/// would expose (its own upstream connection, not this invocation's
+/// `--upstream`/`--no-upstream` flags — see this module's doc comment:
+/// once the socket is reachable, the command is answered by serve's own
+/// state).
+pub(super) fn try_tools_list(root: &Path) -> Option<Result<Vec<Value>, String>> {
+    let stream = UnixStream::connect(socket_path(root)).ok()?;
+    Some(tools_list_over(stream))
+}
+
+/// Build the `figmog tools` row shape (`{name, source, cacheable}`) from a
+/// raw `tools/list` result — shared by the socket path above and, in
+/// principle, any future caller that already has a tool-def array in hand.
+pub(super) fn tools_rows(tools: &[Value]) -> Value {
+    let rows: Vec<Value> = tools
+        .iter()
+        .map(|t| {
+            let name = t["name"].as_str().unwrap_or_default();
+            json!({
+                "name": name,
+                "source": if crate::proxy::is_local_tool(name) { "local" } else { "upstream" },
+                "cacheable": crate::proxy::tool_name_cache_capable(name),
+            })
+        })
+        .collect();
+    Value::Array(rows)
+}
+
+fn call_over(stream: UnixStream, tool: &str, args: Value) -> Result<Value, String> {
+    let resp = send_and_recv(
+        stream,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": args},
+        }),
+    )?;
+    interpret_call_response(resp)
+}
+
+fn tools_list_over(stream: UnixStream) -> Result<Vec<Value>, String> {
+    let resp = send_and_recv(
+        stream,
+        &json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+    )?;
+    if let Some(err) = resp.get("error") {
+        return Err(protocol_error_message(err));
+    }
+    Ok(resp["result"]["tools"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default())
+}
+
+/// One newline-delimited JSON-RPC frame out, one line back — the wire
+/// mechanics every call in this module shares. `initialize` is
+/// deliberately skipped: spec §1 makes it optional for socket clients, and
+/// `mcp::handle_message` treats every frame independently regardless of
+/// handshake state (verified by `serve.rs`'s socket-loop tests), so a bare
+/// `tools/call`/`tools/list` is answered exactly as if a handshake had
+/// happened first.
+fn send_and_recv(stream: UnixStream, frame: &Value) -> Result<Value, String> {
+    stream
+        .set_read_timeout(Some(SOCKET_TIMEOUT))
+        .map_err(|e| e.to_string())?;
+    stream
+        .set_write_timeout(Some(SOCKET_TIMEOUT))
+        .map_err(|e| e.to_string())?;
+    let mut writer = stream.try_clone().map_err(|e| e.to_string())?;
+    writeln!(writer, "{frame}").map_err(|e| format!("writing to serve socket: {e}"))?;
+    writer
+        .flush()
+        .map_err(|e| format!("writing to serve socket: {e}"))?;
+
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    let n = reader
+        .read_line(&mut line)
+        .map_err(|e| format!("reading from serve socket: {e}"))?;
+    if n == 0 {
+        return Err("serve socket closed before responding".to_string());
+    }
+    serde_json::from_str(&line).map_err(|e| format!("serve socket sent invalid JSON: {e}"))
+}
+
+fn protocol_error_message(err: &Value) -> String {
+    err.get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown error")
+        .to_string()
+}
+
+/// Pure translation of one `tools/call` JSON-RPC response into the plain
+/// `Result<Value, String>` shape every CLI command already produces —
+/// split from [`call_over`]'s I/O so it's unit-testable directly against
+/// hand-built response `Value`s.
+fn interpret_call_response(resp: Value) -> Result<Value, String> {
+    if let Some(err) = resp.get("error") {
+        return Err(protocol_error_message(err));
+    }
+    let result = resp.get("result").cloned().unwrap_or(Value::Null);
+    let is_error = result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let text = result["content"][0]["text"].as_str().map(str::to_string);
+
+    if is_error {
+        return Err(text.unwrap_or_else(|| "unknown error from serve".to_string()));
+    }
+
+    match text {
+        // Every local `figmog_*` tool — the only kind this CLI ever calls
+        // over the socket — answers as `ToolOutput::Json`, i.e. one text
+        // content block holding figmog's own JSON (see `mcp::ToolOutput`'s
+        // doc comment); parse it back out rather than handing the caller a
+        // JSON *string* nested inside the MCP envelope.
+        Some(t) => serde_json::from_str(&t)
+            .map_err(|e| format!("serve returned non-JSON tool content: {e}")),
+        // No text content at all: a `Raw` (proxied, non-`figmog_*`) result.
+        // `figmog call` can legitimately name a proxied tool, so this is a
+        // real path, not defensive dead code — pass the whole result
+        // through unchanged, same as direct mode's own proxy_call return.
+        None => Ok(result),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interpret_call_response_parses_json_tool_content() {
+        let resp = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": "{\"ok\":true}"}], "isError": false},
+        });
+        assert_eq!(interpret_call_response(resp).unwrap(), json!({"ok": true}));
+    }
+
+    #[test]
+    fn interpret_call_response_is_error_becomes_err_with_the_message_text() {
+        let resp = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": "no node 99:99 in the mirror"}], "isError": true},
+        });
+        assert_eq!(
+            interpret_call_response(resp).unwrap_err(),
+            "no node 99:99 in the mirror"
+        );
+    }
+
+    #[test]
+    fn interpret_call_response_protocol_error_becomes_err() {
+        let resp = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32601, "message": "method not found"},
+        });
+        assert_eq!(
+            interpret_call_response(resp).unwrap_err(),
+            "method not found"
+        );
+    }
+
+    #[test]
+    fn interpret_call_response_raw_result_with_no_text_content_passes_through() {
+        // A proxied (non-figmog_*) tool's result has no single text block
+        // (e.g. an image content type) — passed through as-is rather than
+        // failed as "non-JSON tool content".
+        let raw_result = json!({
+            "content": [{"type": "image", "data": "YQ==", "mimeType": "image/png"}],
+            "isError": false,
+        });
+        let resp = json!({"jsonrpc": "2.0", "id": 1, "result": raw_result});
+        assert_eq!(interpret_call_response(resp).unwrap(), raw_result);
+    }
+
+    #[test]
+    fn tools_rows_classifies_local_vs_upstream_and_cacheable() {
+        let tools = vec![
+            json!({"name": "figmog_status"}),
+            json!({"name": "get_code"}),
+            json!({"name": "set_selection"}),
+        ];
+        let rows = tools_rows(&tools);
+        let rows = rows.as_array().unwrap();
+        assert_eq!(
+            rows[0],
+            json!({"name": "figmog_status", "source": "local", "cacheable": false})
+        );
+        assert_eq!(
+            rows[1],
+            json!({"name": "get_code", "source": "upstream", "cacheable": true})
+        );
+        assert_eq!(
+            rows[2],
+            json!({"name": "set_selection", "source": "upstream", "cacheable": false})
+        );
+    }
+}

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -515,7 +515,7 @@ pub(crate) fn tool_registry() -> Vec<ToolDef> {
         },
         ToolDef {
             name: "figmog_images",
-            description: "Download node renders and/or fill images (v0.0.2 spec §5), cached by file version — spends Figma API budget (the images endpoints are the most rate-limited; never called automatically). Returns image content blocks (base64) for items up to 1MB, plus a JSON manifest; larger items point at the CLI's `figmog images --out` instead.",
+            description: "Download node renders and/or fill images (v0.0.2 spec §5), cached by file version — spends Figma API budget (the images endpoints are the most rate-limited; never called automatically). Returns a JSON manifest plus, per item up to 1MB encoded: an image content block (base64) for raster formats, or the raw SVG markup as a text block for format=svg; larger items point at the CLI's `figmog images --out` instead.",
             input_schema: json!({
                 "type": "object",
                 "properties": {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -252,7 +252,19 @@ pub(crate) fn dispatch_read_tool<R: Readable>(
         }
         "figmog_where" => Some((|| {
             let pointer = require_str(args, "pointer")?;
-            let equals = args.get("equals").cloned();
+            // A present-but-`Value::Null` `equals` is treated the same as
+            // an absent one (review C2, defense in depth): the primary fix
+            // lives on the CLI's socket-routing side (`cli::strip_nulls`,
+            // since `json!` always emits a null-valued key for an absent
+            // `Option<T>` field rather than omitting it), but any other
+            // caller building this call's JSON by hand — a future tool
+            // client, a hand-rolled MCP request — could reproduce the same
+            // "present null ⇒ silently matches nothing" trap without going
+            // through the CLI at all. This is the one arg here that can't
+            // use `arg_str`/`arg_usize`'s existing `Value::Null.as_*()` ⇒
+            // `None` null-safety, since it carries an arbitrary JSON value
+            // rather than a typed scalar.
+            let equals = args.get("equals").cloned().filter(|v| !v.is_null());
             let page = arg_str(args, "page");
             let under = arg_str(args, "under");
             query::where_(&nodes, &children, &pointer, equals, page, under)

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -17,7 +17,7 @@ use serde_json::{Value, json};
 
 use crate::mcp::ToolDef;
 use crate::model::{
-    ComponentRec, ComponentSetRec, FileMeta, NodeRec, ProxyCacheRec, StyleRec,
+    ComponentRec, ComponentSetRec, FileMeta, MirrorConfigRec, NodeRec, ProxyCacheRec, StyleRec,
     VariableCollectionRec, VariableRec,
 };
 use crate::query;
@@ -36,9 +36,10 @@ pub(crate) type NodeReaders<'a, R> = (
 );
 
 /// Read handles for the whole pipeline, in `figmog_pipeline!`'s top-level
-/// order — the exact tuple `st.rtx`'s closure receives. 8 elements: the
+/// order — the exact tuple `st.rtx`'s closure receives. 9 elements: the
 /// `nodes` branch bundle, then `components`, `component_sets`, `styles`,
-/// `variables`, `variable_collections`, `meta`, `proxy_cache`.
+/// `variables`, `variable_collections`, `meta`, `proxy_cache`,
+/// `mirror_config` (v0.0.2 spec §4 — appended last, non-breaking).
 pub(crate) type RootReaders<'a, R> = (
     NodeReaders<'a, R>,
     TableReader<'a, R, String, ComponentRec>,
@@ -48,6 +49,7 @@ pub(crate) type RootReaders<'a, R> = (
     TableReader<'a, R, String, VariableCollectionRec>,
     TableReader<'a, R, u8, FileMeta>,
     TableReader<'a, R, String, ProxyCacheRec>,
+    TableReader<'a, R, u8, MirrorConfigRec>,
 );
 
 // ---- arg extraction ----
@@ -143,6 +145,7 @@ pub(crate) fn dispatch_read_tool<R: Readable>(
         variable_collections,
         meta,
         _cache,
+        _mirror_config,
     ) = r;
 
     match name {
@@ -496,7 +499,11 @@ pub(crate) fn tool_registry() -> Vec<ToolDef> {
         input_schema: json!({
             "type": "object",
             "properties": {
-                "file": {"type": "string", "description": "Figma file URL or key to mirror."}
+                "file": {"type": "string", "description": "Figma file URL or key to mirror."},
+                "geometry": {
+                    "type": "boolean",
+                    "description": "Request vector path data (fillGeometry/strokeGeometry) on this pull. Sticky (spec §4): once set, every later pull of this mirror keeps requesting it until a `pull --fresh`. Omitted preserves whatever this mirror already has stored; default false for a brand-new mirror."
+                }
             },
             "required": ["file"]
         }),

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,4 +1,4 @@
-//! The 16 read-only `figmog_*` tools: one dispatch function, generic over
+//! The 17 read-only `figmog_*` tools: one dispatch function, generic over
 //! the store's reader types, shared by `figmog serve`'s request loop and
 //! the CLI's `figmog call`/`figmog tools`. (`figmog_sync` is not here — it
 //! writes to the store and drives watch/backoff state that only exists at

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -104,7 +104,22 @@ pub(crate) fn require_f64(args: &Value, key: &str) -> Result<f64, String> {
     }
 }
 
-/// Dispatch one of the 16 read-only `figmog_*` tools against an open
+/// The file key named by a full Figma URL in whichever node-id-shaped
+/// argument this call carries (spec §2b): tries `id`, then `under`, then
+/// `target`, in that order — a given tool call has at most one of these,
+/// so trying all three is safe. `None` when no such argument is present,
+/// or it's present but isn't a URL naming a file (a bare id, or a URL
+/// with no file segment). Used by `figmog serve`'s multi-file session
+/// routing (`serve.rs::handle_tool_call`) to auto-infer the target mirror
+/// from a pasted node/frame URL when the call omits an explicit `file`.
+pub(crate) fn infer_file_from_node_ref(args: &Value) -> Option<String> {
+    ["id", "under", "target"].iter().find_map(|key| {
+        let raw = arg_str(args, key)?;
+        crate::ident::parse_node_ref(&raw)?.0
+    })
+}
+
+/// Dispatch one of the 17 read-only `figmog_*` tools against an open
 /// snapshot. `upstream_status` is spliced into `figmog_status`'s output
 /// (`"connected"` / `"unreachable"` / `"disabled"`) without changing
 /// `query::status`'s own signature (spec §12 point 4).
@@ -146,17 +161,49 @@ pub(crate) fn dispatch_read_tool<R: Readable>(
         "figmog_node" => Some((|| {
             let id = require_str(args, "id")?;
             let with_children = arg_bool(args, "children");
-            query::node(&nodes, &children, id, with_children)
+            let resolve_vars = arg_bool(args, "resolve_vars");
+            query::node(
+                &nodes,
+                &children,
+                &variables,
+                &variable_collections,
+                id,
+                with_children,
+                resolve_vars,
+            )
+        })()),
+        "figmog_subtree" => Some((|| {
+            let id = require_str(args, "id")?;
+            let depth = arg_usize(args, "depth");
+            let fields = args.get("fields").and_then(Value::as_array).map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str())
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            });
+            let resolve_vars = arg_bool(args, "resolve_vars");
+            query::subtree(
+                &nodes,
+                &children,
+                &variables,
+                &variable_collections,
+                id,
+                depth,
+                fields.as_deref(),
+                resolve_vars,
+            )
         })()),
         "figmog_find" => Some((|| {
             let node_type = require_str(args, "type")?;
             let page = arg_str(args, "page");
-            query::find(&nodes, &by_type, node_type, page)
+            let under = arg_str(args, "under");
+            query::find(&nodes, &children, &by_type, node_type, page, under)
         })()),
         "figmog_search" => Some((|| {
             let q = require_str(args, "query")?;
             let limit = arg_usize(args, "limit").unwrap_or(10);
-            query::search(&text, &nodes, &q, limit)
+            let under = arg_str(args, "under");
+            query::search(&text, &nodes, &children, &q, limit, under)
         })()),
         "figmog_instances" => Some((|| {
             let target = require_str(args, "target")?;
@@ -166,8 +213,16 @@ pub(crate) fn dispatch_read_tool<R: Readable>(
         "figmog_styles" => {
             let style_type = arg_str(args, "type");
             let values = arg_bool(args, "values");
+            let resolve_vars = arg_bool(args, "resolve_vars");
             Some(query::styles(
-                &nodes, &styles, &styled_by, style_type, values,
+                &nodes,
+                &styles,
+                &styled_by,
+                &variables,
+                &variable_collections,
+                style_type,
+                values,
+                resolve_vars,
             ))
         }
         "figmog_uses" => Some((|| {
@@ -192,13 +247,15 @@ pub(crate) fn dispatch_read_tool<R: Readable>(
         })()),
         "figmog_text" => {
             let page = arg_str(args, "page");
-            Some(query::text(&nodes, &by_type, page))
+            let under = arg_str(args, "under");
+            Some(query::text(&nodes, &children, &by_type, page, under))
         }
         "figmog_where" => Some((|| {
             let pointer = require_str(args, "pointer")?;
             let equals = args.get("equals").cloned();
             let page = arg_str(args, "page");
-            query::where_(&nodes, &pointer, equals, page)
+            let under = arg_str(args, "under");
+            query::where_(&nodes, &children, &pointer, equals, page, under)
         })()),
         "figmog_at" => Some((|| {
             let x = require_f64(args, "x")?;
@@ -220,11 +277,11 @@ fn file_arg_property() -> Value {
     })
 }
 
-/// The 19 `figmog_*` MCP tools (spec §14, v4): the 12 core reads + 5
-/// whole-file structural queries + `figmog_sync` (build design §11's two
-/// tables) — every one of those 17 gains the optional `file` routing
-/// property below — plus the two v4 additions, `figmog_open` and
-/// `figmog_files`, which don't (routing *to* a file, and listing every
+/// The 20 `figmog_*` MCP tools (spec §14, v4; `figmog_subtree` added by
+/// v0.0.2 §2): 17 reads of the local mirror (`figmog_subtree` among them)
+/// plus `figmog_sync` — 18 total — every one of which gains the optional
+/// `file` routing property below — plus the two v4 additions, `figmog_open`
+/// and `figmog_files`, which don't (routing *to* a file, and listing every
 /// file, aren't themselves per-file operations). Every tool but
 /// `figmog_sync`/`figmog_open` reads the local mirror at zero Figma API
 /// cost.
@@ -253,36 +310,57 @@ pub(crate) fn tool_registry() -> Vec<ToolDef> {
         },
         ToolDef {
             name: "figmog_node",
-            description: "Full raw JSON of one node by id, optionally with a one-level children summary — reads the local mirror (no Figma API cost).",
+            description: "Full raw JSON of one node by id, optionally with a one-level children summary and/or a resolved_variables annotation — reads the local mirror (no Figma API cost).",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "id": {"type": "string", "description": "Node id (12:34 or 12-34 form)."},
-                    "children": {"type": "boolean", "description": "Inline a one-level children summary."}
+                    "children": {"type": "boolean", "description": "Inline a one-level children summary."},
+                    "resolve_vars": {"type": "boolean", "description": "Annotate boundVariables binding sites with variable names/values under a resolved_variables key."}
+                },
+                "required": ["id"]
+            }),
+        },
+        ToolDef {
+            name: "figmog_subtree",
+            description: "Full raw JSON of a node and its descendants, nested under `children` in child-index order — reads the local mirror (no Figma API cost). Use `depth` and `fields` to keep the response small; an unbounded dump of a large subtree can be huge.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Root node id (12:34 or 12-34 form)."},
+                    "depth": {"type": "integer", "description": "Max depth to descend; omitted means unlimited."},
+                    "fields": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Project every node to these raw fields (id/name/type/children always survive). Recommended for large subtrees."
+                    },
+                    "resolve_vars": {"type": "boolean", "description": "Annotate boundVariables binding sites with variable names/values under a resolved_variables key."}
                 },
                 "required": ["id"]
             }),
         },
         ToolDef {
             name: "figmog_find",
-            description: "Nodes by Figma node type, optionally scoped to one page — reads the local mirror (no Figma API cost).",
+            description: "Nodes by Figma node type, optionally scoped to one page and/or a subtree — reads the local mirror (no Figma API cost).",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "type": {"type": "string", "description": "Figma node type, e.g. FRAME."},
-                    "page": {"type": "string", "description": "Page (CANVAS) node id to scope to."}
+                    "page": {"type": "string", "description": "Page (CANVAS) node id to scope to."},
+                    "under": {"type": "string", "description": "Scope to the subtree rooted at this node id (inclusive)."}
                 },
                 "required": ["type"]
             }),
         },
         ToolDef {
             name: "figmog_search",
-            description: "BM25 search over layer names and text content — reads the local mirror (no Figma API cost).",
+            description: "BM25 search over layer names and text content, optionally scoped to a subtree — reads the local mirror (no Figma API cost).",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "query": {"type": "string"},
-                    "limit": {"type": "integer", "description": "Max hits (default 10)."}
+                    "limit": {"type": "integer", "description": "Max hits (default 10)."},
+                    "under": {"type": "string", "description": "Scope to the subtree rooted at this node id (inclusive)."}
                 },
                 "required": ["query"]
             }),
@@ -310,7 +388,8 @@ pub(crate) fn tool_registry() -> Vec<ToolDef> {
                 "type": "object",
                 "properties": {
                     "type": {"type": "string", "description": "Style type filter, e.g. FILL, TEXT."},
-                    "values": {"type": "boolean", "description": "Derive each style's definition from a consumer node."}
+                    "values": {"type": "boolean", "description": "Derive each style's definition from a consumer node."},
+                    "resolve_vars": {"type": "boolean", "description": "With values, annotate the definition's variable bindings under a resolved_variables key."}
                 }
             }),
         },
@@ -352,21 +431,25 @@ pub(crate) fn tool_registry() -> Vec<ToolDef> {
         },
         ToolDef {
             name: "figmog_text",
-            description: "Every TEXT node's (id, characters, page_id), optionally scoped to one page, sorted by id — reads the local mirror (no Figma API cost).",
+            description: "Every TEXT node's (id, characters, page_id), optionally scoped to one page and/or a subtree, sorted by id — reads the local mirror (no Figma API cost).",
             input_schema: json!({
                 "type": "object",
-                "properties": {"page": {"type": "string"}}
+                "properties": {
+                    "page": {"type": "string"},
+                    "under": {"type": "string", "description": "Scope to the subtree rooted at this node id (inclusive)."}
+                }
             }),
         },
         ToolDef {
             name: "figmog_where",
-            description: "Nodes whose raw JSON matches an RFC 6901 pointer, optionally filtered by value — reads the local mirror (no Figma API cost).",
+            description: "Nodes whose raw JSON matches an RFC 6901 pointer, optionally filtered by value and/or scoped to a page/subtree — reads the local mirror (no Figma API cost).",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "pointer": {"type": "string", "description": "RFC 6901 pointer into the node's raw JSON, e.g. /layoutMode."},
                     "equals": {"description": "JSON value to match; omitted means \"pointer exists\"."},
-                    "page": {"type": "string"}
+                    "page": {"type": "string"},
+                    "under": {"type": "string", "description": "Scope to the subtree rooted at this node id (inclusive)."}
                 },
                 "required": ["pointer"]
             }),

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -17,8 +17,8 @@ use serde_json::{Value, json};
 
 use crate::mcp::ToolDef;
 use crate::model::{
-    ComponentRec, ComponentSetRec, FileMeta, MirrorConfigRec, NodeRec, ProxyCacheRec, StyleRec,
-    VariableCollectionRec, VariableRec,
+    ComponentRec, ComponentSetRec, FileMeta, ImageBlobRec, MirrorConfigRec, NodeRec, ProxyCacheRec,
+    StyleRec, VariableCollectionRec, VariableRec,
 };
 use crate::query;
 
@@ -36,10 +36,11 @@ pub(crate) type NodeReaders<'a, R> = (
 );
 
 /// Read handles for the whole pipeline, in `figmog_pipeline!`'s top-level
-/// order — the exact tuple `st.rtx`'s closure receives. 9 elements: the
+/// order — the exact tuple `st.rtx`'s closure receives. 10 elements: the
 /// `nodes` branch bundle, then `components`, `component_sets`, `styles`,
 /// `variables`, `variable_collections`, `meta`, `proxy_cache`,
-/// `mirror_config` (v0.0.2 spec §4 — appended last, non-breaking).
+/// `mirror_config` (v0.0.2 spec §4), `images` (v0.0.2 spec §5 — appended
+/// last, non-breaking).
 pub(crate) type RootReaders<'a, R> = (
     NodeReaders<'a, R>,
     TableReader<'a, R, String, ComponentRec>,
@@ -50,6 +51,7 @@ pub(crate) type RootReaders<'a, R> = (
     TableReader<'a, R, u8, FileMeta>,
     TableReader<'a, R, String, ProxyCacheRec>,
     TableReader<'a, R, u8, MirrorConfigRec>,
+    TableReader<'a, R, String, ImageBlobRec>,
 );
 
 // ---- arg extraction ----
@@ -93,6 +95,44 @@ pub(crate) fn arg_usize(args: &Value, key: &str) -> Option<usize> {
 
 pub(crate) fn arg_bool(args: &Value, key: &str) -> bool {
     args.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
+/// Optional numeric field — [`require_f64`]'s absent-is-`None` sibling,
+/// used by `figmog_images`'s optional `scale` (v0.0.2 spec §5).
+pub(crate) fn arg_f64(args: &Value, key: &str) -> Option<f64> {
+    args.get(key).and_then(Value::as_f64)
+}
+
+/// A required array-of-strings field — `figmog_images`'s `ids` (v0.0.2
+/// spec §5). Same present-but-wrong-type distinction as [`require_str`];
+/// additionally rejects an empty array (nothing to fetch) and a non-string
+/// element, both named precisely rather than surfacing as a generic
+/// downstream failure.
+pub(crate) fn require_str_array(args: &Value, key: &str) -> Result<Vec<String>, String> {
+    match args.get(key) {
+        None => Err(format!("missing required field: {key}")),
+        Some(Value::Array(items)) => {
+            if items.is_empty() {
+                return Err(format!("`{key}` must not be empty"));
+            }
+            items
+                .iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    v.as_str().map(str::to_string).ok_or_else(|| {
+                        format!(
+                            "expected string for `{key}[{i}]`, got {}",
+                            json_type_name(v)
+                        )
+                    })
+                })
+                .collect()
+        }
+        Some(other) => Err(format!(
+            "expected array for `{key}`, got {}",
+            json_type_name(other)
+        )),
+    }
 }
 
 /// See [`require_str`]'s doc comment — same present-but-wrong-type
@@ -146,6 +186,7 @@ pub(crate) fn dispatch_read_tool<R: Readable>(
         meta,
         _cache,
         _mirror_config,
+        _images,
     ) = r;
 
     match name {
@@ -292,14 +333,17 @@ fn file_arg_property() -> Value {
     })
 }
 
-/// The 20 `figmog_*` MCP tools (spec §14, v4; `figmog_subtree` added by
-/// v0.0.2 §2): 17 reads of the local mirror (`figmog_subtree` among them)
-/// plus `figmog_sync` — 18 total — every one of which gains the optional
-/// `file` routing property below — plus the two v4 additions, `figmog_open`
-/// and `figmog_files`, which don't (routing *to* a file, and listing every
+/// The 21 `figmog_*` MCP tools (spec §14, v4; `figmog_subtree` added by
+/// v0.0.2 §2, `figmog_images` by v0.0.2 §5): 17 reads of the local mirror
+/// (`figmog_subtree` among them) plus `figmog_sync` and `figmog_images` —
+/// 19 total — every one of which gains the optional `file` routing
+/// property below — plus the two v4 additions, `figmog_open` and
+/// `figmog_files`, which don't (routing *to* a file, and listing every
 /// file, aren't themselves per-file operations). Every tool but
-/// `figmog_sync`/`figmog_open` reads the local mirror at zero Figma API
-/// cost.
+/// `figmog_sync`/`figmog_open`/`figmog_images` reads the local mirror at
+/// zero Figma API cost — `figmog_images` is deliberately never called
+/// automatically by anything in figmog (spec §5: the images endpoints are
+/// Figma's most rate-limited).
 pub(crate) fn tool_registry() -> Vec<ToolDef> {
     let mut tools = vec![
         ToolDef {
@@ -467,6 +511,23 @@ pub(crate) fn tool_registry() -> Vec<ToolDef> {
                     "under": {"type": "string", "description": "Scope to the subtree rooted at this node id (inclusive)."}
                 },
                 "required": ["pointer"]
+            }),
+        },
+        ToolDef {
+            name: "figmog_images",
+            description: "Download node renders and/or fill images (v0.0.2 spec §5), cached by file version — spends Figma API budget (the images endpoints are the most rate-limited; never called automatically). Returns image content blocks (base64) for items up to 1MB, plus a JSON manifest; larger items point at the CLI's `figmog images --out` instead.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Node ids (or Figma URLs carrying node-id=) to render, and/or to scan for fill imageRefs."
+                    },
+                    "format": {"type": "string", "description": "Render format: png or svg (default png)."},
+                    "scale": {"type": "number", "description": "Render scale (default 1)."}
+                },
+                "required": ["ids"]
             }),
         },
         ToolDef {

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -30,6 +30,78 @@ pub fn normalize_node_id(input: &str) -> String {
     input.to_string()
 }
 
+/// Parse a node-id input that may be a bare id or a full Figma URL
+/// carrying `node-id=` in its query (spec §2b — the README's promised
+/// quick-start prompt pastes a frame URL directly, and every node-id
+/// input accepts one). Returns `(file_key, node_id)`: `file_key` is
+/// `Some` only when the URL also names a file ([`parse_file_ref`]'s own
+/// URL forms — `/design/`, `/file/`, `/board/`); `node_id` is always
+/// normalized ([`normalize_node_id`]'s `0-1` ⇒ `0:1` rule).
+///
+/// A bare (non-URL) `input` always succeeds and passes through
+/// unchanged/normalized — "Bare ids: byte-identical behavior to today"
+/// (spec §2b). A Figma URL with no `node-id=` in its query can't name a
+/// node at all, so that case is `None` rather than silently normalizing
+/// the whole URL string as if it were an id.
+pub fn parse_node_ref(input: &str) -> Option<(Option<String>, String)> {
+    if !input.contains("figma.com/") {
+        return Some((None, normalize_node_id(input)));
+    }
+    let raw_id = query_param(input, "node-id")?;
+    let file_key = parse_file_ref(input);
+    Some((file_key, normalize_node_id(&raw_id)))
+}
+
+/// [`parse_node_ref`] plus a fallback for the cases it can't extract a
+/// node id from (a non-Figma-URL string that isn't a bare id shape either
+/// — can't happen, [`parse_node_ref`] always succeeds there — or a Figma
+/// URL with no `node-id=`): falls back to the raw input, same as
+/// [`normalize_node_id`] would do with any unrecognized shape. The file
+/// key half is discarded — every `query::*` call site this feeds already
+/// operates against one already-resolved store; only `figmog serve`'s
+/// multi-file session routing (`serve.rs`) needs the file key, and calls
+/// [`parse_node_ref`] directly for that.
+pub fn normalize_node_ref(input: &str) -> String {
+    parse_node_ref(input)
+        .map(|(_, id)| id)
+        .unwrap_or_else(|| input.to_string())
+}
+
+/// First `key=value` pair named `key` in `url`'s query string (the part
+/// after `?`, before any `#` fragment), percent-decoded. `None` if `url`
+/// has no query string or no pair named `key`.
+fn query_param(url: &str, key: &str) -> Option<String> {
+    let (_, query) = url.split_once('?')?;
+    let query = query.split('#').next().unwrap_or(query);
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k == key).then(|| percent_decode(v))
+    })
+}
+
+/// Minimal `%XX` percent-decoder. Figma node ids in a URL query are ASCII
+/// digits/`:`/`-`/`;` (instance paths), so a byte-level decode is
+/// sufficient — no `+`-as-space handling, since a query *value* here is
+/// never form-encoded space-separated text.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let Ok(byte) = u8::from_str_radix(&s[i + 1..i + 3], 16)
+        {
+            out.push(byte);
+            i += 3;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -71,5 +143,76 @@ mod tests {
         assert_eq!(normalize_node_id("12:345"), "12:345");
         // instance sub-node paths pass through untouched
         assert_eq!(normalize_node_id("I206:7;104:22"), "I206:7;104:22");
+    }
+
+    #[test]
+    fn parse_node_ref_passes_bare_ids_through_normalized() {
+        assert_eq!(
+            parse_node_ref("0-1"),
+            Some((None, "0:1".to_string())),
+            "bare id: normalized, no file key"
+        );
+        assert_eq!(
+            parse_node_ref("I206:7;104:22"),
+            Some((None, "I206:7;104:22".to_string())),
+            "bare instance path: unchanged, byte-identical to normalize_node_id"
+        );
+    }
+
+    #[test]
+    fn parse_node_ref_extracts_node_id_from_a_url() {
+        // node-id only, no file segment in this particular URL shape.
+        assert_eq!(
+            parse_node_ref("https://www.figma.com/board/abc/whatever?node-id=12-345"),
+            Some((None, "12:345".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_node_ref_is_none_for_a_figma_url_with_no_node_id() {
+        assert_eq!(
+            parse_node_ref("https://www.figma.com/file/flAtUnMfzvA5daBSTFQK35/whatever"),
+            None,
+            "no node-id in the query: nothing to address, not a bare-id fallback"
+        );
+    }
+
+    #[test]
+    fn parse_node_ref_extracts_both_file_key_and_node_id() {
+        assert_eq!(
+            parse_node_ref(
+                "https://www.figma.com/design/flAtUnMfzvA5daBSTFQK35/g3d-Index-Web-Handoff?node-id=0-1&t=x-1"
+            ),
+            Some((
+                Some("flAtUnMfzvA5daBSTFQK35".to_string()),
+                "0:1".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_node_ref_percent_decodes_the_node_id() {
+        assert_eq!(
+            parse_node_ref("https://www.figma.com/file/abc/x?node-id=1%3A2"),
+            Some((None, "1:2".to_string())),
+            "1%3A2 decodes to 1:2, already canonical, normalize_node_id leaves it alone"
+        );
+    }
+
+    #[test]
+    fn normalize_node_ref_discards_the_file_key_and_falls_back_when_unresolvable() {
+        assert_eq!(normalize_node_ref("0-1"), "0:1");
+        assert_eq!(
+            normalize_node_ref("https://www.figma.com/design/flAtUnMfzvA5daBSTFQK35/x?node-id=1-2"),
+            "1:2"
+        );
+        // A Figma URL with no node-id can't be resolved to an id at all;
+        // normalize_node_ref falls back to the raw input rather than
+        // erroring, same as normalize_node_id does for any unrecognized
+        // shape — the caller's `nodes.get` lookup will simply not find it.
+        assert_eq!(
+            normalize_node_ref("https://www.figma.com/file/abc/whatever"),
+            "https://www.figma.com/file/abc/whatever"
+        );
     }
 }

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -83,6 +83,14 @@ fn query_param(url: &str, key: &str) -> Option<String> {
 /// digits/`:`/`-`/`;` (instance paths), so a byte-level decode is
 /// sufficient — no `+`-as-space handling, since a query *value* here is
 /// never form-encoded space-separated text.
+///
+/// Operates on `s.as_bytes()` throughout and never slices `s` itself by
+/// byte index: `%` followed by a multibyte UTF-8 char (e.g. `%aé`) would
+/// otherwise let `i + 1..i + 3` land mid-char and panic on the
+/// not-a-char-boundary slice. `is_ascii_hexdigit` is checked on the raw
+/// bytes first, so a non-hex (including non-ASCII) byte after `%` always
+/// takes the malformed-escape fallback below instead of ever indexing
+/// into `s`.
 fn percent_decode(s: &str) -> String {
     let bytes = s.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());
@@ -90,12 +98,19 @@ fn percent_decode(s: &str) -> String {
     while i < bytes.len() {
         if bytes[i] == b'%'
             && i + 2 < bytes.len()
-            && let Ok(byte) = u8::from_str_radix(&s[i + 1..i + 3], 16)
+            && bytes[i + 1].is_ascii_hexdigit()
+            && bytes[i + 2].is_ascii_hexdigit()
         {
-            out.push(byte);
+            let hi = (bytes[i + 1] as char).to_digit(16).unwrap();
+            let lo = (bytes[i + 2] as char).to_digit(16).unwrap();
+            out.push((hi * 16 + lo) as u8);
             i += 3;
             continue;
         }
+        // Malformed escape (no `%`, truncated, or non-hex bytes follow):
+        // pass the current byte through literally and re-scan from the
+        // next one, same fallback the previous `str`-slicing version used
+        // for a non-hex tail.
         out.push(bytes[i]);
         i += 1;
     }
@@ -197,6 +212,22 @@ mod tests {
             Some((None, "1:2".to_string())),
             "1%3A2 decodes to 1:2, already canonical, normalize_node_id leaves it alone"
         );
+    }
+
+    #[test]
+    fn percent_decode_never_panics_on_a_hex_escape_followed_by_multibyte_utf8() {
+        // F1 regression: `%` + one ASCII byte + a multibyte char used to
+        // slice `&s[i+1..i+3]` mid-char and panic ("byte index 3 is not a
+        // char boundary"). Malformed escapes fall back to passing the `%`
+        // (and whatever follows) through literally, same as a non-hex tail
+        // always has.
+        assert_eq!(percent_decode("%aé"), "%aé");
+        assert_eq!(percent_decode("%é"), "%é");
+        assert_eq!(percent_decode("%"), "%");
+        assert_eq!(percent_decode("%a"), "%a");
+        // Valid escapes are unaffected.
+        assert_eq!(percent_decode("%3A"), ":");
+        assert_eq!(percent_decode("1%3A2"), "1:2");
     }
 
     #[test]

--- a/src/images.rs
+++ b/src/images.rs
@@ -1,0 +1,1073 @@
+//! Image bytes fetch orchestration (v0.0.2 spec §5): version-cached node
+//! renders and fill images, shared by the CLI `figmog images` command
+//! (`cli::images`) and `figmog serve`'s `figmog_images` tool
+//! (`sessions::FileSession::images`, wired in `serve.rs`).
+//!
+//! Two fetch kinds behind one call: **renders** (`GET /v1/images/:key`,
+//! one node → one image) and **fills** (`GET /v1/files/:key/images`, a
+//! file-wide `imageRef` hash → URL map, scanned out of the *requested*
+//! nodes' raw `fills` arrays). Both are cached in the `images` table,
+//! keyed by [`image_key`] and version-gated exactly like `proxy_cache`
+//! (`store::stale_image_ids` / `store::evict_stale_cache`) — a repeat
+//! request against an unchanged file spends zero Figma API calls.
+//!
+//! **Two-step call shape.** [`scan`] (read-only, against already-open
+//! table readers) then [`resolve`] (network + cache-write, against
+//! `&mut KeyedStream<Id, Rec, P>`) rather than one function that does
+//! both: `KeyedStream`'s pipeline type is unnameable outside its own
+//! `open_store!` expansion site (see `dispatch.rs`'s and `store.rs`'s own
+//! doc comments on the same constraint), so a function generic over
+//! `P: Push<..>` can call `st.wtx(..)` (as `resolve` does — writes don't
+//! hit this) but can't destructure `st.rtx(..)`'s reader tuple, since that
+//! tuple's type is `P`'s own opaque associated type. Every caller
+//! therefore calls `st.rtx(|tuple| scan(..))` at its own concrete
+//! `open_store!` call site, then passes the result into `resolve` —
+//! exactly the shape `store::collect_sweepable` + `store::sync` already
+//! use at `cli::pull::do_pull` and `sessions::open_session_at`.
+//!
+//! `resolve`'s network dependencies are both injected (`api: Option<&dyn
+//! FigmaApi>`, `download: &dyn Fn(&str) -> Result<Vec<u8>, ApiError>`) so
+//! this module's own tests exercise the full orchestration — cache
+//! hit/miss, the fills dedup, per-item 429/error handling — against a
+//! scripted fake, with no live network call anywhere in this crate's test
+//! suite (documented per the v0.0.2 plan: images has no automated
+//! live-network test).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use fold::pipeline::terminal::TableReader;
+use fold::pipeline::{Keyed, Push};
+use fold::stream::{KeyedStream, Readable};
+use serde_json::{Value, json};
+
+use crate::api::{ApiError, FigmaApi};
+use crate::ident::normalize_node_ref;
+use crate::model::{FileMeta, Id, ImageBlobRec, NodeRec, Rec};
+
+/// [`ImageItem::kind`] for a node render.
+pub const RENDER: &str = "render";
+/// [`ImageItem::kind`] for a fill image.
+pub const FILL: &str = "fill";
+
+/// A caller with no Figma API token still gets every cache hit for free
+/// (spec §5: "a repeat request on an unchanged file spends zero budget");
+/// every miss gets this exact per-item manifest error instead of a wasted
+/// (guaranteed-401) network attempt.
+const NO_TOKEN_MSG: &str = "FIGMA_TOKEN not set — required for image downloads";
+
+/// Content blocks over roughly this many bytes are excluded from the MCP
+/// tool's inline `image` content (spec §5's "1MB" cap) — 1 MiB exactly,
+/// matching the spec's own "1MB each" wording as closely as a byte count
+/// can.
+pub const CONTENT_SIZE_CAP: usize = 1_048_576;
+
+/// Deterministic hex key for one cached image row: FNV-1a 64 (same
+/// constants and separator discipline as `cache::cache_key`'s own doc
+/// comment, extended from two fields to four) over `kind`+NUL+`subject`+
+/// NUL+`format`+NUL+`scale_milli` (decimal) — a boundary shift across any
+/// adjacent pair can't collide two distinct cache rows.
+///
+/// Fills are never format-parameterized (Figma's fills endpoint takes no
+/// `format` query — a given `imageRef` always resolves to the same
+/// bytes), so every fill lookup/store call passes `format = ""` here
+/// regardless of the format actually discovered on download; only render
+/// keys vary by the caller's requested format.
+pub fn image_key(kind: &str, subject: &str, format: &str, scale_milli: u32) -> String {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let scale_str = scale_milli.to_string();
+    let mut hash = OFFSET_BASIS;
+    for byte in kind
+        .as_bytes()
+        .iter()
+        .chain(std::iter::once(&0u8))
+        .chain(subject.as_bytes())
+        .chain(std::iter::once(&0u8))
+        .chain(format.as_bytes())
+        .chain(std::iter::once(&0u8))
+        .chain(scale_str.as_bytes())
+    {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    format!("{hash:016x}")
+}
+
+/// `scale` (a caller-facing `f64`, e.g. `1.5`) as the integer milli-scale
+/// [`ImageBlobRec::scale_milli`]/[`image_key`] store — `None` (Figma's own
+/// default) is `1000` (1×).
+pub fn scale_milli(scale: Option<f64>) -> u32 {
+    match scale {
+        Some(s) => (s * 1000.0).round().clamp(0.0, u32::MAX as f64) as u32,
+        None => 1000,
+    }
+}
+
+/// Normalize and dedup a caller's raw id list — accepts anything
+/// `ident::normalize_node_ref` does (bare ids, `0-1` dash form, Figma URLs
+/// carrying `node-id=`, spec §2b) — preserving first-seen order. Callers
+/// run this once and pass the same `Vec` to both [`scan`] and [`resolve`].
+pub fn normalize_ids(ids: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    for raw in ids {
+        let id = normalize_node_ref(raw);
+        if seen.insert(id.clone()) {
+            out.push(id);
+        }
+    }
+    out
+}
+
+/// One fetched (or cache-hit) image: a node render or a fill image, ready
+/// for a caller to write to disk and/or wrap as MCP content.
+#[derive(Debug, Clone)]
+pub struct ImageItem {
+    /// Node id (`kind == RENDER`) or `imageRef` hash (`kind == FILL`).
+    pub subject: String,
+    pub kind: &'static str,
+    pub format: String,
+    /// Empty when `error.is_some()`.
+    pub bytes: Vec<u8>,
+    pub cached: bool,
+    pub error: Option<String>,
+}
+
+impl ImageItem {
+    /// This item's manifest row: `{"id"|"ref": subject, "kind", "format",
+    /// "bytes": <byte count>, "cached", "error"?}` — `id` for a render,
+    /// `ref` for a fill (spec §5: `[{id|ref, kind, path, bytes, cached}]`).
+    /// Never carries raw bytes or a `path` — callers (`cli::images`,
+    /// `serve.rs`'s tool wrapping) layer those in themselves, since only
+    /// the CLI knows about `--out` files at all.
+    pub fn manifest_entry(&self) -> Value {
+        let mut obj = serde_json::Map::new();
+        let subject_key = if self.kind == RENDER { "id" } else { "ref" };
+        obj.insert(subject_key.to_string(), json!(self.subject));
+        obj.insert("kind".to_string(), json!(self.kind));
+        obj.insert("format".to_string(), json!(self.format));
+        obj.insert("bytes".to_string(), json!(self.bytes.len()));
+        obj.insert("cached".to_string(), json!(self.cached));
+        if let Some(e) = &self.error {
+            obj.insert("error".to_string(), json!(e));
+        }
+        Value::Object(obj)
+    }
+}
+
+/// Everything the read-only half of image fetching can determine from the
+/// mirror alone, with no network access: the current file version, every
+/// render/fill cache hit, and the set of `imageRef`s the requested nodes'
+/// raw `fills` reference. Produced by [`scan`], consumed by [`resolve`] —
+/// see this module's doc comment for why they're split at all.
+pub struct Scanned {
+    version: String,
+    render_hits: BTreeMap<String, ImageItem>,
+    fill_refs: BTreeSet<String>,
+    fill_hits: BTreeMap<String, ImageItem>,
+}
+
+/// Read-only half of image fetching: cache lookups plus fill-ref
+/// detection, against already-open table readers — call inside
+/// `st.rtx(|tuple| images::scan(..))` at a concrete `open_store!` site.
+/// `node_ids` must already be normalized/deduped ([`normalize_ids`]).
+pub fn scan<R: Readable>(
+    nodes: &TableReader<'_, R, String, NodeRec>,
+    meta: &TableReader<'_, R, u8, FileMeta>,
+    images: &TableReader<'_, R, String, ImageBlobRec>,
+    node_ids: &[String],
+    format: &str,
+    scale_milli: u32,
+) -> Scanned {
+    let version = meta.get(&0).map(|m| m.version.clone()).unwrap_or_default();
+
+    let mut render_hits: BTreeMap<String, ImageItem> = BTreeMap::new();
+    for id in node_ids {
+        let key = image_key(RENDER, id, format, scale_milli);
+        if let Some(rec) = images.get(&key)
+            && rec.file_version == version
+        {
+            render_hits.insert(
+                id.clone(),
+                ImageItem {
+                    subject: id.clone(),
+                    kind: RENDER,
+                    format: format.to_string(),
+                    bytes: rec.bytes.clone(),
+                    cached: true,
+                    error: None,
+                },
+            );
+        }
+    }
+
+    let mut fill_refs: BTreeSet<String> = BTreeSet::new();
+    for id in node_ids {
+        if let Some(n) = nodes.get(id)
+            && let Ok(raw) = serde_json::from_str::<Value>(&n.raw)
+        {
+            fill_refs.extend(extract_image_refs(&raw));
+        }
+    }
+
+    let mut fill_hits: BTreeMap<String, ImageItem> = BTreeMap::new();
+    for r in &fill_refs {
+        let key = image_key(FILL, r, "", 1000);
+        if let Some(rec) = images.get(&key)
+            && rec.file_version == version
+        {
+            fill_hits.insert(
+                r.clone(),
+                ImageItem {
+                    subject: r.clone(),
+                    kind: FILL,
+                    format: rec.format.clone(),
+                    bytes: rec.bytes.clone(),
+                    cached: true,
+                    error: None,
+                },
+            );
+        }
+    }
+
+    Scanned {
+        version,
+        render_hits,
+        fill_refs,
+        fill_hits,
+    }
+}
+
+/// Network + cache-write half of image fetching: fetch every render/fill
+/// miss `scan` didn't already resolve — at most one `images_render` call
+/// covering every render miss, at most one `file_image_fills` call
+/// covering every distinct `imageRef` miss (spec §5) — cache the results,
+/// and return every item in `node_ids`' request order followed by the
+/// scanned fill refs' sorted order. `api: None` means "no Figma API token
+/// available": cache hits still resolve fully; every miss gets a
+/// `"FIGMA_TOKEN not set"` error instead of a network attempt.
+#[allow(clippy::too_many_arguments)]
+pub fn resolve<P: Push<Keyed<Id, Rec>>>(
+    st: &mut KeyedStream<Id, Rec, P>,
+    scanned: Scanned,
+    api: Option<&dyn FigmaApi>,
+    download: &dyn Fn(&str) -> Result<Vec<u8>, ApiError>,
+    file_key: &str,
+    node_ids: &[String],
+    format: &str,
+    scale: Option<f64>,
+) -> Vec<ImageItem> {
+    let Scanned {
+        version,
+        mut render_hits,
+        fill_refs,
+        mut fill_hits,
+    } = scanned;
+    let scale_m = scale_milli(scale);
+
+    let render_misses: Vec<String> = node_ids
+        .iter()
+        .filter(|id| !render_hits.contains_key(*id))
+        .cloned()
+        .collect();
+    if !render_misses.is_empty() {
+        match api {
+            None => {
+                for id in &render_misses {
+                    render_hits.insert(id.clone(), no_token_item(RENDER, id, format));
+                }
+            }
+            Some(api) => match api.images_render(file_key, &render_misses, format, scale) {
+                Ok(resp) => {
+                    let url_map = resp.get("images").and_then(Value::as_object);
+                    for id in &render_misses {
+                        let url = url_map.and_then(|m| m.get(id)).and_then(Value::as_str);
+                        let item = match url {
+                            None => error_item(
+                                RENDER,
+                                id,
+                                format.to_string(),
+                                "no render available for this node".to_string(),
+                            ),
+                            Some(url) => match download(url) {
+                                Ok(bytes) => {
+                                    let key = image_key(RENDER, id, format, scale_m);
+                                    store_image(
+                                        st, &key, RENDER, id, format, scale_m, &version, &bytes,
+                                    );
+                                    ImageItem {
+                                        subject: id.clone(),
+                                        kind: RENDER,
+                                        format: format.to_string(),
+                                        bytes,
+                                        cached: false,
+                                        error: None,
+                                    }
+                                }
+                                Err(e) => error_item(RENDER, id, format.to_string(), e.to_string()),
+                            },
+                        };
+                        render_hits.insert(id.clone(), item);
+                    }
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    for id in &render_misses {
+                        render_hits.insert(
+                            id.clone(),
+                            error_item(RENDER, id, format.to_string(), msg.clone()),
+                        );
+                    }
+                }
+            },
+        }
+    }
+
+    let fill_misses: Vec<String> = fill_refs
+        .iter()
+        .filter(|r| !fill_hits.contains_key(*r))
+        .cloned()
+        .collect();
+    if !fill_misses.is_empty() {
+        match api {
+            None => {
+                for r in &fill_misses {
+                    fill_hits.insert(r.clone(), no_token_item(FILL, r, ""));
+                }
+            }
+            Some(api) => match api.file_image_fills(file_key) {
+                Ok(resp) => {
+                    // Figma's own response nests under `meta.images`; tolerate
+                    // a bare `images` map too (this crate's own test fixtures
+                    // don't need to reproduce the wrapper exactly).
+                    let url_map = resp
+                        .get("meta")
+                        .and_then(|m| m.get("images"))
+                        .and_then(Value::as_object)
+                        .or_else(|| resp.get("images").and_then(Value::as_object));
+                    for r in &fill_misses {
+                        let url = url_map.and_then(|m| m.get(r)).and_then(Value::as_str);
+                        let item = match url {
+                            None => error_item(
+                                FILL,
+                                r,
+                                String::new(),
+                                "no fill image available for this imageRef".to_string(),
+                            ),
+                            Some(url) => match download(url) {
+                                Ok(bytes) => {
+                                    let fmt = infer_fill_format(url);
+                                    let key = image_key(FILL, r, "", 1000);
+                                    store_image(st, &key, FILL, r, &fmt, 1000, &version, &bytes);
+                                    ImageItem {
+                                        subject: r.clone(),
+                                        kind: FILL,
+                                        format: fmt,
+                                        bytes,
+                                        cached: false,
+                                        error: None,
+                                    }
+                                }
+                                Err(e) => error_item(FILL, r, String::new(), e.to_string()),
+                            },
+                        };
+                        fill_hits.insert(r.clone(), item);
+                    }
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    for r in &fill_misses {
+                        fill_hits
+                            .insert(r.clone(), error_item(FILL, r, String::new(), msg.clone()));
+                    }
+                }
+            },
+        }
+    }
+
+    let mut out = Vec::with_capacity(node_ids.len() + fill_refs.len());
+    for id in node_ids {
+        if let Some(item) = render_hits.remove(id) {
+            out.push(item);
+        }
+    }
+    for r in &fill_refs {
+        if let Some(item) = fill_hits.remove(r) {
+            out.push(item);
+        }
+    }
+    out
+}
+
+fn no_token_item(kind: &'static str, subject: &str, format: &str) -> ImageItem {
+    ImageItem {
+        subject: subject.to_string(),
+        kind,
+        format: format.to_string(),
+        bytes: Vec::new(),
+        cached: false,
+        error: Some(NO_TOKEN_MSG.to_string()),
+    }
+}
+
+fn error_item(kind: &'static str, subject: &str, format: String, error: String) -> ImageItem {
+    ImageItem {
+        subject: subject.to_string(),
+        kind,
+        format,
+        bytes: Vec::new(),
+        cached: false,
+        error: Some(error),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn store_image<P: Push<Keyed<Id, Rec>>>(
+    st: &mut KeyedStream<Id, Rec, P>,
+    key: &str,
+    kind: &str,
+    subject: &str,
+    format: &str,
+    scale_milli: u32,
+    file_version: &str,
+    bytes: &[u8],
+) {
+    let rec = ImageBlobRec {
+        key_hash: key.to_string(),
+        kind: kind.to_string(),
+        subject: subject.to_string(),
+        format: format.to_string(),
+        scale_milli,
+        file_version: file_version.to_string(),
+        bytes: bytes.to_vec(),
+    };
+    st.wtx(|tx| {
+        tx.upsert(
+            &Id::ImageBlob(key.to_string()),
+            &Rec::ImageBlob(rec.clone()),
+        );
+    });
+}
+
+/// Distinct `imageRef` hashes among a raw node JSON's `fills` array
+/// (`fills[].type == "IMAGE"`, `fills[].imageRef`) — the fill-detection
+/// half of spec §5. Any other fill type (`SOLID`, `GRADIENT_*`) or a
+/// missing/non-array `fills` yields nothing.
+fn extract_image_refs(raw: &Value) -> Vec<String> {
+    let Some(fills) = raw.get("fills").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    fills
+        .iter()
+        .filter(|f| f.get("type").and_then(Value::as_str) == Some("IMAGE"))
+        .filter_map(|f| f.get("imageRef").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Best-effort format for a fill's bytes, from its download URL's file
+/// extension (Figma's fills endpoint carries no format of its own — see
+/// [`image_key`]'s doc comment) — informational only, defaulting to
+/// `"png"` when the URL has no recognizable extension.
+fn infer_fill_format(url: &str) -> String {
+    let path = url.split('?').next().unwrap_or(url);
+    if let Some(idx) = path.rfind('.') {
+        let ext = &path[idx + 1..];
+        if !ext.is_empty() && ext.len() <= 4 && ext.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return ext.to_ascii_lowercase();
+        }
+    }
+    "png".to_string()
+}
+
+fn mime_for(format: &str) -> &'static str {
+    match format.to_ascii_lowercase().as_str() {
+        "svg" => "image/svg+xml",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        _ => "image/png",
+    }
+}
+
+/// Build the MCP `tools/call` result for `figmog_images` (spec §5):
+/// content is always `[manifest text block, image blocks...]` — the
+/// manifest first and always text, so a socket-routed CLI client (see
+/// `cli::images`) can find it at `content[0]` unambiguously regardless of
+/// how many (if any) image blocks follow. One `image` block per item that
+/// downloaded successfully and is at or under [`CONTENT_SIZE_CAP`], in the
+/// same order as `items`; an oversized success gets an extra text note
+/// instead (an error item gets neither — its manifest entry already
+/// carries the reason).
+pub fn to_mcp_content(items: &[ImageItem]) -> Value {
+    let manifest: Vec<Value> = items.iter().map(ImageItem::manifest_entry).collect();
+    let mut content = vec![json!({
+        "type": "text",
+        "text": serde_json::to_string(&manifest).unwrap_or_default(),
+    })];
+    for item in items {
+        if item.error.is_some() {
+            continue;
+        }
+        let subject_key = if item.kind == RENDER { "id" } else { "ref" };
+        // Non-standard extra field on both arms below, ignored by MCP
+        // clients that don't know it — lets a socket-routed CLI caller
+        // (`cli::images`, the only consumer that reads it) match a block
+        // back to its manifest row without relying on content order alone
+        // (an oversized item contributes a `text` block instead of an
+        // `image` one at the same position, so a plain index zip would
+        // misalign).
+        let mut block = if item.bytes.len() <= CONTENT_SIZE_CAP {
+            serde_json::Map::from_iter([
+                ("type".to_string(), json!("image")),
+                ("data".to_string(), json!(base64_encode(&item.bytes))),
+                ("mimeType".to_string(), json!(mime_for(&item.format))),
+            ])
+        } else {
+            serde_json::Map::from_iter([
+                ("type".to_string(), json!("text")),
+                (
+                    "text".to_string(),
+                    json!(format!(
+                        "{} {}={} is {} bytes, over the 1MB inline cap — run `figmog images {} --out <dir>` to download it to disk.",
+                        item.kind,
+                        subject_key,
+                        item.subject,
+                        item.bytes.len(),
+                        item.subject
+                    )),
+                ),
+            ])
+        };
+        block.insert(subject_key.to_string(), json!(item.subject));
+        content.push(Value::Object(block));
+    }
+    json!({"content": content, "isError": false})
+}
+
+// ---- base64 (no crate dependency — see `api::download_bytes`'s doc
+// comment for why the MCP wire format needs base64 at all) ----
+
+const B64_ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+pub(crate) fn base64_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = chunk.get(1).copied().unwrap_or(0);
+        let b2 = chunk.get(2).copied().unwrap_or(0);
+        let n = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+        out.push(B64_ALPHABET[((n >> 18) & 0x3F) as usize] as char);
+        out.push(B64_ALPHABET[((n >> 12) & 0x3F) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            B64_ALPHABET[((n >> 6) & 0x3F) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            B64_ALPHABET[(n & 0x3F) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+pub(crate) fn base64_decode(s: &str) -> Result<Vec<u8>, String> {
+    fn val(b: u8) -> Result<u32, String> {
+        match b {
+            b'A'..=b'Z' => Ok((b - b'A') as u32),
+            b'a'..=b'z' => Ok((b - b'a' + 26) as u32),
+            b'0'..=b'9' => Ok((b - b'0' + 52) as u32),
+            b'+' => Ok(62),
+            b'/' => Ok(63),
+            _ => Err(format!("invalid base64 byte: {b}")),
+        }
+    }
+    let s = s.trim();
+    if !s.len().is_multiple_of(4) {
+        return Err("base64 input length must be a multiple of 4".to_string());
+    }
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(s.len() / 4 * 3);
+    for chunk in bytes.chunks(4) {
+        let pad = chunk.iter().filter(|&&b| b == b'=').count();
+        let mut n: u32 = 0;
+        for &b in chunk {
+            n <<= 6;
+            if b != b'=' {
+                n |= val(b)?;
+            }
+        }
+        out.push((n >> 16) as u8);
+        if pad < 2 {
+            out.push((n >> 8) as u8);
+        }
+        if pad < 1 {
+            out.push(n as u8);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    use crate::api::FileMetaResp;
+    use crate::model::NodeRec;
+
+    // ---- image_key ----
+
+    #[test]
+    fn image_key_is_deterministic() {
+        assert_eq!(
+            image_key(RENDER, "1:2", "png", 1000),
+            image_key(RENDER, "1:2", "png", 1000)
+        );
+    }
+
+    #[test]
+    fn image_key_distinguishes_kind_subject_format_and_scale() {
+        let base = image_key(RENDER, "1:2", "png", 1000);
+        assert_ne!(base, image_key(FILL, "1:2", "png", 1000));
+        assert_ne!(base, image_key(RENDER, "1:3", "png", 1000));
+        assert_ne!(base, image_key(RENDER, "1:2", "svg", 1000));
+        assert_ne!(base, image_key(RENDER, "1:2", "png", 2000));
+    }
+
+    #[test]
+    fn image_key_distinguishes_boundary_shift() {
+        // Same separator-discipline proof as `cache::cache_key`'s own test.
+        assert_ne!(
+            image_key("ab", "c", "", 1000),
+            image_key("a", "bc", "", 1000)
+        );
+    }
+
+    #[test]
+    fn scale_milli_defaults_to_1000_and_rounds() {
+        assert_eq!(scale_milli(None), 1000);
+        assert_eq!(scale_milli(Some(1.0)), 1000);
+        assert_eq!(scale_milli(Some(1.5)), 1500);
+        assert_eq!(scale_milli(Some(0.333)), 333);
+    }
+
+    #[test]
+    fn normalize_ids_dedups_and_normalizes_dash_form() {
+        let ids = vec!["0-1".to_string(), "0:1".to_string(), "1-2".to_string()];
+        assert_eq!(
+            normalize_ids(&ids),
+            vec!["0:1".to_string(), "1:2".to_string()]
+        );
+    }
+
+    // ---- extract_image_refs / infer_fill_format ----
+
+    #[test]
+    fn extract_image_refs_finds_image_fills_and_ignores_others() {
+        let raw = json!({
+            "fills": [
+                {"type": "SOLID", "color": {"r": 1}},
+                {"type": "IMAGE", "imageRef": "abc123"},
+                {"type": "IMAGE", "imageRef": "def456"},
+            ]
+        });
+        let mut refs = extract_image_refs(&raw);
+        refs.sort();
+        assert_eq!(refs, vec!["abc123".to_string(), "def456".to_string()]);
+    }
+
+    #[test]
+    fn extract_image_refs_empty_when_no_fills() {
+        assert_eq!(extract_image_refs(&json!({})), Vec::<String>::new());
+    }
+
+    #[test]
+    fn infer_fill_format_reads_the_url_extension() {
+        assert_eq!(infer_fill_format("https://s3/x/y.jpg?sig=1"), "jpg");
+        assert_eq!(infer_fill_format("https://s3/x/y.PNG"), "png");
+        assert_eq!(infer_fill_format("https://s3/x/y"), "png");
+    }
+
+    // ---- base64 ----
+
+    #[test]
+    fn base64_round_trips_classic_vectors() {
+        for (raw, encoded) in [
+            ("", ""),
+            ("f", "Zg=="),
+            ("fo", "Zm8="),
+            ("foo", "Zm9v"),
+            ("foob", "Zm9vYg=="),
+            ("fooba", "Zm9vYmE="),
+            ("foobar", "Zm9vYmFy"),
+        ] {
+            assert_eq!(base64_encode(raw.as_bytes()), encoded, "encode {raw:?}");
+            assert_eq!(
+                base64_decode(encoded).unwrap(),
+                raw.as_bytes().to_vec(),
+                "decode {encoded:?}"
+            );
+        }
+    }
+
+    // ---- manifest_entry / to_mcp_content ----
+
+    #[test]
+    fn manifest_entry_uses_id_for_render_and_ref_for_fill() {
+        let render = ImageItem {
+            subject: "1:2".into(),
+            kind: RENDER,
+            format: "png".into(),
+            bytes: vec![1, 2, 3],
+            cached: false,
+            error: None,
+        };
+        assert_eq!(
+            render.manifest_entry(),
+            json!({"id": "1:2", "kind": "render", "format": "png", "bytes": 3, "cached": false})
+        );
+
+        let fill = ImageItem {
+            subject: "abc".into(),
+            kind: FILL,
+            format: "jpg".into(),
+            bytes: vec![],
+            cached: true,
+            error: Some("boom".into()),
+        };
+        assert_eq!(
+            fill.manifest_entry(),
+            json!({"ref": "abc", "kind": "fill", "format": "jpg", "bytes": 0, "cached": true, "error": "boom"})
+        );
+    }
+
+    #[test]
+    fn to_mcp_content_orders_manifest_first_then_images_skipping_errors_and_oversized() {
+        let ok = ImageItem {
+            subject: "1:2".into(),
+            kind: RENDER,
+            format: "png".into(),
+            bytes: vec![1, 2, 3],
+            cached: false,
+            error: None,
+        };
+        let failed = ImageItem {
+            subject: "1:3".into(),
+            kind: RENDER,
+            format: "png".into(),
+            bytes: vec![],
+            cached: false,
+            error: Some("rate limited".into()),
+        };
+        let oversized = ImageItem {
+            subject: "1:4".into(),
+            kind: RENDER,
+            format: "png".into(),
+            bytes: vec![0u8; CONTENT_SIZE_CAP + 1],
+            cached: false,
+            error: None,
+        };
+        let out = to_mcp_content(&[ok.clone(), failed, oversized]);
+        let content = out["content"].as_array().unwrap();
+        // manifest first, always text
+        assert_eq!(content[0]["type"], json!("text"));
+        let manifest: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(manifest.as_array().unwrap().len(), 3);
+        // one image block for the successful, under-cap item, tagged with
+        // its node id so a socket-routed CLI caller can match it back up.
+        assert_eq!(content[1]["type"], json!("image"));
+        assert_eq!(content[1]["mimeType"], json!("image/png"));
+        assert_eq!(content[1]["data"], json!(base64_encode(&ok.bytes)));
+        assert_eq!(content[1]["id"], json!("1:2"));
+        // one text note for the oversized item, also tagged; nothing at
+        // all for the error item.
+        assert_eq!(content[2]["type"], json!("text"));
+        assert!(content[2]["text"].as_str().unwrap().contains("--out"));
+        assert_eq!(content[2]["id"], json!("1:4"));
+        assert_eq!(content.len(), 3);
+        assert_eq!(out["isError"], json!(false));
+    }
+
+    // ---- scan + resolve: scripted FigmaApi fake ----
+
+    /// Pops one scripted response per call (same pattern as
+    /// `watch::tests::Script`), and records every call it received so
+    /// tests can assert on dedup/call counts.
+    struct Script {
+        render_responses: RefCell<Vec<Result<Value, ApiError>>>,
+        fills_responses: RefCell<Vec<Result<Value, ApiError>>>,
+        render_calls: RefCell<Vec<Vec<String>>>,
+        fills_calls: RefCell<u32>,
+    }
+    impl Script {
+        fn new() -> Self {
+            Script {
+                render_responses: RefCell::new(Vec::new()),
+                fills_responses: RefCell::new(Vec::new()),
+                render_calls: RefCell::new(Vec::new()),
+                fills_calls: RefCell::new(0),
+            }
+        }
+    }
+    impl FigmaApi for Script {
+        fn file_meta(&self, _key: &str) -> Result<FileMetaResp, ApiError> {
+            unimplemented!("not exercised by images::resolve")
+        }
+        fn file(&self, _key: &str, _geometry: bool) -> Result<Value, ApiError> {
+            unimplemented!("not exercised by images::resolve")
+        }
+        fn images_render(
+            &self,
+            _key: &str,
+            ids: &[String],
+            _format: &str,
+            _scale: Option<f64>,
+        ) -> Result<Value, ApiError> {
+            self.render_calls.borrow_mut().push(ids.to_vec());
+            self.render_responses.borrow_mut().remove(0)
+        }
+        fn file_image_fills(&self, _key: &str) -> Result<Value, ApiError> {
+            *self.fills_calls.borrow_mut() += 1;
+            self.fills_responses.borrow_mut().remove(0)
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn downloader(
+        bytes: HashMap<String, Vec<u8>>,
+    ) -> (
+        impl Fn(&str) -> Result<Vec<u8>, ApiError>,
+        std::rc::Rc<RefCell<u32>>,
+    ) {
+        let calls = std::rc::Rc::new(RefCell::new(0u32));
+        let calls2 = calls.clone();
+        let f = move |url: &str| -> Result<Vec<u8>, ApiError> {
+            *calls2.borrow_mut() += 1;
+            bytes
+                .get(url)
+                .cloned()
+                .ok_or_else(|| ApiError::Network(format!("no fixture bytes for {url}")))
+        };
+        (f, calls)
+    }
+
+    fn insert_node<P: Push<Keyed<Id, Rec>>>(
+        st: &mut KeyedStream<Id, Rec, P>,
+        node_id: &str,
+        raw: Value,
+    ) {
+        st.wtx(|tx| {
+            tx.upsert(
+                &Id::Node(node_id.to_string()),
+                &Rec::Node(NodeRec {
+                    id: node_id.to_string(),
+                    parent_id: Some("0:1".into()),
+                    child_index: 0,
+                    page_id: "0:1".into(),
+                    node_type: "RECTANGLE".into(),
+                    name: "N".into(),
+                    visible: true,
+                    text: None,
+                    component_id: None,
+                    component_properties: vec![],
+                    property_definitions: None,
+                    style_refs: vec![],
+                    bound_variables: vec![],
+                    abs_bounds: None,
+                    raw: raw.to_string(),
+                }),
+            );
+        });
+    }
+
+    fn insert_meta<P: Push<Keyed<Id, Rec>>>(st: &mut KeyedStream<Id, Rec, P>, version: &str) {
+        st.wtx(|tx| {
+            tx.upsert(
+                &Id::Meta,
+                &Rec::Meta(crate::model::FileMeta {
+                    name: "F".into(),
+                    version: version.to_string(),
+                    last_modified: "t".into(),
+                    synced_at_unix_ms: 0,
+                }),
+            );
+        });
+    }
+
+    /// `scan` then `resolve`, exactly the two-step call every production
+    /// call site makes (this module's own doc comment) — the one seam
+    /// this test suite proves end to end.
+    macro_rules! scan_and_resolve {
+        ($st:expr, $api:expr, $download:expr, $ids:expr, $format:expr, $scale:expr) => {{
+            let scanned = $st.rtx(|((nodes, ..), _, _, _, _, _, meta, _, _, images)| {
+                scan(&nodes, &meta, &images, $ids, $format, scale_milli($scale))
+            });
+            resolve(
+                &mut $st, scanned, $api, $download, "FILE", $ids, $format, $scale,
+            )
+        }};
+    }
+
+    #[test]
+    fn resolve_render_miss_downloads_and_caches_then_a_repeat_call_hits_cache_with_zero_api_calls()
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let mut st = crate::open_store!(dir.path().join("db"));
+        insert_node(&mut st, "1:2", json!({}));
+        insert_meta(&mut st, "100");
+
+        let script = Script::new();
+        script
+            .render_responses
+            .borrow_mut()
+            .push(Ok(json!({"images": {"1:2": "https://s3/render.png"}})));
+        let (download, download_calls) = downloader(HashMap::from([(
+            "https://s3/render.png".to_string(),
+            vec![1, 2, 3, 4],
+        )]));
+
+        let ids = vec!["1:2".to_string()];
+        let items = scan_and_resolve!(st, Some(&script), &download, &ids, "png", None);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].bytes, vec![1, 2, 3, 4]);
+        assert!(!items[0].cached);
+        assert!(items[0].error.is_none());
+        assert_eq!(*download_calls.borrow(), 1);
+        assert_eq!(script.render_calls.borrow().len(), 1);
+
+        // Second call: cache hit. `Script`'s render_responses is now empty,
+        // so a second `images_render` call would panic on `.remove(0)` —
+        // proving zero API calls happened, not just asserting a counter.
+        let items2 = scan_and_resolve!(st, Some(&script), &download, &ids, "png", None);
+        assert_eq!(items2.len(), 1);
+        assert_eq!(items2[0].bytes, vec![1, 2, 3, 4]);
+        assert!(items2[0].cached);
+        assert_eq!(
+            *download_calls.borrow(),
+            1,
+            "cache hit must not re-download"
+        );
+    }
+
+    #[test]
+    fn resolve_detects_fill_image_refs_and_fetches_the_map_at_most_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut st = crate::open_store!(dir.path().join("db"));
+        insert_node(
+            &mut st,
+            "1:2",
+            json!({"fills": [{"type": "IMAGE", "imageRef": "hash1"}]}),
+        );
+        insert_meta(&mut st, "100");
+
+        let script = Script::new();
+        script
+            .render_responses
+            .borrow_mut()
+            .push(Ok(json!({"images": {"1:2": "https://s3/render.png"}})));
+        script.fills_responses.borrow_mut().push(Ok(
+            json!({"meta": {"images": {"hash1": "https://s3/fill.jpg"}}}),
+        ));
+        let (download, _calls) = downloader(HashMap::from([
+            ("https://s3/render.png".to_string(), vec![9]),
+            ("https://s3/fill.jpg".to_string(), vec![5, 5, 5]),
+        ]));
+
+        let ids = vec!["1:2".to_string()];
+        let items = scan_and_resolve!(st, Some(&script), &download, &ids, "png", None);
+        assert_eq!(items.len(), 2, "one render + one fill");
+        let fill = items.iter().find(|i| i.kind == FILL).unwrap();
+        assert_eq!(fill.subject, "hash1");
+        assert_eq!(fill.bytes, vec![5, 5, 5]);
+        assert_eq!(fill.format, "jpg");
+        assert_eq!(*script.fills_calls.borrow(), 1);
+
+        // Cache hit path for the fill: `fills_responses` is now empty, so a
+        // second call would panic if the fill map were re-fetched.
+        let items2 = scan_and_resolve!(st, Some(&script), &download, &ids, "png", None);
+        let fill2 = items2.iter().find(|i| i.kind == FILL).unwrap();
+        assert!(fill2.cached);
+        assert_eq!(*script.fills_calls.borrow(), 1);
+    }
+
+    #[test]
+    fn resolve_records_a_missing_render_url_as_a_per_item_error_without_failing_other_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut st = crate::open_store!(dir.path().join("db"));
+        insert_node(&mut st, "1:2", json!({}));
+        insert_node(&mut st, "1:3", json!({}));
+        insert_meta(&mut st, "100");
+
+        let script = Script::new();
+        // Figma omits 1:3 from the map — not renderable.
+        script
+            .render_responses
+            .borrow_mut()
+            .push(Ok(json!({"images": {"1:2": "https://s3/render.png"}})));
+        let (download, _calls) = downloader(HashMap::from([(
+            "https://s3/render.png".to_string(),
+            vec![7],
+        )]));
+
+        let ids = vec!["1:2".to_string(), "1:3".to_string()];
+        let items = scan_and_resolve!(st, Some(&script), &download, &ids, "png", None);
+        assert_eq!(items.len(), 2);
+        let ok = items.iter().find(|i| i.subject == "1:2").unwrap();
+        assert!(ok.error.is_none());
+        assert_eq!(ok.bytes, vec![7]);
+        let missing = items.iter().find(|i| i.subject == "1:3").unwrap();
+        assert!(missing.error.is_some());
+        assert!(missing.bytes.is_empty());
+    }
+
+    #[test]
+    fn resolve_without_api_serves_cache_hits_and_marks_misses_with_the_no_token_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut st = crate::open_store!(dir.path().join("db"));
+        insert_node(&mut st, "1:2", json!({}));
+        insert_node(&mut st, "1:3", json!({}));
+        insert_meta(&mut st, "100");
+        // Pre-seed a cache hit for 1:2 directly (as if fetched earlier).
+        {
+            let key = image_key(RENDER, "1:2", "png", 1000);
+            store_image(&mut st, &key, RENDER, "1:2", "png", 1000, "100", &[1, 1]);
+        }
+        let (download, download_calls) = downloader(HashMap::new());
+
+        let ids = vec!["1:2".to_string(), "1:3".to_string()];
+        let items = scan_and_resolve!(st, None, &download, &ids, "png", None);
+        assert_eq!(items.len(), 2);
+        let cached = items.iter().find(|i| i.subject == "1:2").unwrap();
+        assert!(cached.cached);
+        assert_eq!(cached.bytes, vec![1, 1]);
+        let miss = items.iter().find(|i| i.subject == "1:3").unwrap();
+        assert_eq!(miss.error.as_deref(), Some(NO_TOKEN_MSG));
+        assert_eq!(*download_calls.borrow(), 0);
+    }
+
+    #[test]
+    fn resolve_records_a_429_uniformly_across_every_render_miss() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut st = crate::open_store!(dir.path().join("db"));
+        insert_node(&mut st, "1:2", json!({}));
+        insert_meta(&mut st, "100");
+
+        let script = Script::new();
+        script
+            .render_responses
+            .borrow_mut()
+            .push(Err(ApiError::RateLimited {
+                retry_after: std::time::Duration::from_secs(30),
+            }));
+        let (download, _calls) = downloader(HashMap::new());
+        let ids = vec!["1:2".to_string()];
+        let items = scan_and_resolve!(st, Some(&script), &download, &ids, "png", None);
+        assert_eq!(items.len(), 1);
+        let err = items[0].error.as_deref().unwrap();
+        assert!(err.contains("rate limited"), "{err}");
+    }
+}

--- a/src/images.rs
+++ b/src/images.rs
@@ -56,9 +56,18 @@ pub const FILL: &str = "fill";
 const NO_TOKEN_MSG: &str = "FIGMA_TOKEN not set — required for image downloads";
 
 /// Content blocks over roughly this many bytes are excluded from the MCP
-/// tool's inline `image` content (spec §5's "1MB" cap) — 1 MiB exactly,
-/// matching the spec's own "1MB each" wording as closely as a byte count
-/// can.
+/// tool's inline content (spec §5's "1MB" cap) — 1 MiB exactly, matching
+/// the spec's own "1MB each" wording as closely as a byte count can.
+///
+/// **Measured on the encoded payload actually shipped, not raw image
+/// bytes.** A raster image ships as base64, which inflates the raw byte
+/// count by roughly 4/3 (RFC 4648) — a ~786KB PNG becomes a ~1.05MB
+/// `data` string, already over this cap even though the *file* is well
+/// under 1MB. `to_mcp_content` therefore encodes once, measures the
+/// encoded string's length, and compares that (see its own doc comment).
+/// SVG ships as raw text (no base64 step — see that function's SVG
+/// branch), so for SVG this cap is measured on the markup's own UTF-8
+/// byte length directly, which happens to equal the raw byte count.
 pub const CONTENT_SIZE_CAP: usize = 1_048_576;
 
 /// Deterministic hex key for one cached image row: FNV-1a 64 (same
@@ -168,6 +177,30 @@ pub struct Scanned {
     fill_hits: BTreeMap<String, ImageItem>,
 }
 
+/// Whether a row fetched by its key hash actually belongs to the
+/// requested `(kind, subject)` pair (and, for a render, the requested
+/// `format`/`scale_milli` too) — the same "never trust the key hash
+/// alone" discipline `cache::lookup` documents (I-3 there): a
+/// non-cryptographic FNV-64 hash is trivially collidable, and a colliding
+/// row must read as a miss, not get served as a different item's bytes.
+/// Fills skip the format/scale check on purpose: [`image_key`] always
+/// keys a fill's row with `format = ""`/`scale_milli = 1000` regardless
+/// of the format actually discovered on download (see that function's
+/// own doc comment), so checking the *stored* `format` there would reject
+/// every legitimate fill hit, not just collisions.
+fn matches_identity(
+    rec: &ImageBlobRec,
+    kind: &str,
+    subject: &str,
+    format: &str,
+    scale_milli: u32,
+) -> bool {
+    if rec.kind != kind || rec.subject != subject {
+        return false;
+    }
+    kind != RENDER || (rec.format == format && rec.scale_milli == scale_milli)
+}
+
 /// Read-only half of image fetching: cache lookups plus fill-ref
 /// detection, against already-open table readers — call inside
 /// `st.rtx(|tuple| images::scan(..))` at a concrete `open_store!` site.
@@ -187,6 +220,7 @@ pub fn scan<R: Readable>(
         let key = image_key(RENDER, id, format, scale_milli);
         if let Some(rec) = images.get(&key)
             && rec.file_version == version
+            && matches_identity(&rec, RENDER, id, format, scale_milli)
         {
             render_hits.insert(
                 id.clone(),
@@ -216,6 +250,7 @@ pub fn scan<R: Readable>(
         let key = image_key(FILL, r, "", 1000);
         if let Some(rec) = images.get(&key)
             && rec.file_version == version
+            && matches_identity(&rec, FILL, r, "", 1000)
         {
             fill_hits.insert(
                 r.clone(),
@@ -491,14 +526,30 @@ fn mime_for(format: &str) -> &'static str {
 }
 
 /// Build the MCP `tools/call` result for `figmog_images` (spec §5):
-/// content is always `[manifest text block, image blocks...]` — the
+/// content is always `[manifest text block, per-item blocks...]` — the
 /// manifest first and always text, so a socket-routed CLI client (see
 /// `cli::images`) can find it at `content[0]` unambiguously regardless of
-/// how many (if any) image blocks follow. One `image` block per item that
-/// downloaded successfully and is at or under [`CONTENT_SIZE_CAP`], in the
-/// same order as `items`; an oversized success gets an extra text note
-/// instead (an error item gets neither — its manifest entry already
-/// carries the reason).
+/// how many (if any) data-bearing blocks follow. Per successful item, in
+/// the same order as `items`:
+///
+/// - **SVG** (`item.format` case-insensitively `"svg"`) ships as a
+///   **`text`** block carrying the raw markup verbatim — never base64 nor
+///   `image/svg+xml` (spec ruling): raw SVG text is more directly useful
+///   to an agent generating HTML/CSS than an opaque image blob, and MCP
+///   clients render `image/svg+xml` image blocks inconsistently. The
+///   block also carries a `mimeType: "image/svg+xml"` field (informational
+///   only — MCP's `text` content type doesn't define one) so a consumer
+///   can tell an actual-SVG-content block apart from an oversized note
+///   below without guessing from prose.
+/// - **Every other format** ships as an `image` block, base64-encoded.
+///
+/// Either way, over [`CONTENT_SIZE_CAP`] (measured on the *encoded*
+/// payload — the block's own `text`/`data` string — not the raw byte
+/// count; see that constant's doc comment) gets a plain text note instead
+/// (no `mimeType`, the marker above's absence is what makes it
+/// distinguishable from a real SVG block), pointing at `figmog images
+/// --out`. An error item gets neither — its manifest entry already
+/// carries the reason.
 pub fn to_mcp_content(items: &[ImageItem]) -> Value {
     let manifest: Vec<Value> = items.iter().map(ImageItem::manifest_entry).collect();
     let mut content = vec![json!({
@@ -510,39 +561,65 @@ pub fn to_mcp_content(items: &[ImageItem]) -> Value {
             continue;
         }
         let subject_key = if item.kind == RENDER { "id" } else { "ref" };
-        // Non-standard extra field on both arms below, ignored by MCP
-        // clients that don't know it — lets a socket-routed CLI caller
-        // (`cli::images`, the only consumer that reads it) match a block
-        // back to its manifest row without relying on content order alone
-        // (an oversized item contributes a `text` block instead of an
-        // `image` one at the same position, so a plain index zip would
-        // misalign).
-        let mut block = if item.bytes.len() <= CONTENT_SIZE_CAP {
-            serde_json::Map::from_iter([
-                ("type".to_string(), json!("image")),
-                ("data".to_string(), json!(base64_encode(&item.bytes))),
-                ("mimeType".to_string(), json!(mime_for(&item.format))),
-            ])
+        let is_svg = item.format.eq_ignore_ascii_case("svg");
+
+        // Non-standard extra field(s) on every arm below, ignored by MCP
+        // clients that don't know them — let a socket-routed CLI caller
+        // (`cli::images`, the only consumer that reads them) match a
+        // block back to its manifest row, and tell payload from note
+        // apart, without relying on content order alone (an oversized
+        // item's block sits at the same position a payload block would).
+        let mut block = if is_svg {
+            let text = String::from_utf8_lossy(&item.bytes).into_owned();
+            if text.len() <= CONTENT_SIZE_CAP {
+                serde_json::Map::from_iter([
+                    ("type".to_string(), json!("text")),
+                    ("text".to_string(), json!(text)),
+                    ("mimeType".to_string(), json!(mime_for(&item.format))),
+                ])
+            } else {
+                oversized_note(item, subject_key, text.len())
+            }
         } else {
-            serde_json::Map::from_iter([
-                ("type".to_string(), json!("text")),
-                (
-                    "text".to_string(),
-                    json!(format!(
-                        "{} {}={} is {} bytes, over the 1MB inline cap — run `figmog images {} --out <dir>` to download it to disk.",
-                        item.kind,
-                        subject_key,
-                        item.subject,
-                        item.bytes.len(),
-                        item.subject
-                    )),
-                ),
-            ])
+            let encoded = base64_encode(&item.bytes);
+            if encoded.len() <= CONTENT_SIZE_CAP {
+                serde_json::Map::from_iter([
+                    ("type".to_string(), json!("image")),
+                    ("data".to_string(), json!(encoded)),
+                    ("mimeType".to_string(), json!(mime_for(&item.format))),
+                ])
+            } else {
+                oversized_note(item, subject_key, encoded.len())
+            }
         };
         block.insert(subject_key.to_string(), json!(item.subject));
         content.push(Value::Object(block));
     }
     json!({"content": content, "isError": false})
+}
+
+/// The "too large to inline" text block for one item — deliberately never
+/// carries a `mimeType` field, the signal [`to_mcp_content`]'s consumers
+/// use to tell "this text block IS the payload" (an SVG success) from
+/// "this text block is a note" (this function's output).
+/// `encoded_len` is whatever [`to_mcp_content`] actually measured against
+/// [`CONTENT_SIZE_CAP`] (an encoded byte count, not necessarily
+/// `item.bytes.len()` — see that function's own doc comment).
+fn oversized_note(
+    item: &ImageItem,
+    subject_key: &str,
+    encoded_len: usize,
+) -> serde_json::Map<String, Value> {
+    serde_json::Map::from_iter([
+        ("type".to_string(), json!("text")),
+        (
+            "text".to_string(),
+            json!(format!(
+                "{} {}={} is {encoded_len} bytes encoded, over the 1MB inline cap — run `figmog images {} --out <dir>` to download it to disk.",
+                item.kind, subject_key, item.subject, item.subject
+            )),
+        ),
+    ])
 }
 
 // ---- base64 (no crate dependency — see `api::download_bytes`'s doc
@@ -792,6 +869,90 @@ mod tests {
         assert_eq!(out["isError"], json!(false));
     }
 
+    /// I2: the cap must bound the *encoded* payload, not the raw byte
+    /// count — 800,000 raw bytes is comfortably under
+    /// `CONTENT_SIZE_CAP` (1,048,576), but base64's ~4/3 inflation (RFC
+    /// 4648) pushes the actual `data` string this item would ship as over
+    /// it, so it must still fall back to the oversized note.
+    #[test]
+    fn to_mcp_content_caps_on_encoded_length_not_raw_bytes() {
+        let raw_len = 800_000;
+        assert!(raw_len <= CONTENT_SIZE_CAP, "sanity: raw is under the cap");
+        let encoded_len = base64_encode(&vec![0u8; raw_len]).len();
+        assert!(
+            encoded_len > CONTENT_SIZE_CAP,
+            "sanity: encoded crosses the cap"
+        );
+
+        let item = ImageItem {
+            subject: "1:2".into(),
+            kind: RENDER,
+            format: "png".into(),
+            bytes: vec![0u8; raw_len],
+            cached: false,
+            error: None,
+        };
+        let out = to_mcp_content(&[item]);
+        let content = out["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(
+            content[1]["type"],
+            json!("text"),
+            "must fall back to the oversized note, not an image block, once the encoded size crosses the cap"
+        );
+        assert!(
+            content[1]["mimeType"].is_null(),
+            "an oversized note must never carry mimeType — that field is the payload marker"
+        );
+    }
+
+    /// SVG ruling: an SVG render ships as raw markup in a `text` block
+    /// (never base64/`image/svg+xml`), tagged with `mimeType:
+    /// "image/svg+xml"` so a consumer can tell it apart from an oversized
+    /// note (also `text`, but with no `mimeType`).
+    #[test]
+    fn to_mcp_content_ships_svg_as_raw_text_markup_not_base64_image() {
+        let svg = "<svg><rect/></svg>";
+        let item = ImageItem {
+            subject: "1:2".into(),
+            kind: RENDER,
+            format: "svg".into(),
+            bytes: svg.as_bytes().to_vec(),
+            cached: false,
+            error: None,
+        };
+        let out = to_mcp_content(&[item]);
+        let content = out["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[1]["type"], json!("text"));
+        assert_eq!(content[1]["text"], json!(svg));
+        assert_eq!(content[1]["mimeType"], json!("image/svg+xml"));
+        assert_eq!(content[1]["id"], json!("1:2"));
+    }
+
+    /// SVG ruling, size-cap half: the cap still applies to SVG text, same
+    /// encoded-length comparison — for SVG there's no base64 step, so
+    /// "encoded length" is just the markup's own UTF-8 byte length.
+    #[test]
+    fn to_mcp_content_oversized_svg_falls_back_to_a_note_without_mimetype() {
+        let item = ImageItem {
+            subject: "1:2".into(),
+            kind: RENDER,
+            format: "svg".into(),
+            bytes: vec![b'a'; CONTENT_SIZE_CAP + 1],
+            cached: false,
+            error: None,
+        };
+        let out = to_mcp_content(&[item]);
+        let content = out["content"].as_array().unwrap();
+        assert_eq!(content[1]["type"], json!("text"));
+        assert!(
+            content[1]["mimeType"].is_null(),
+            "an oversized SVG note must not carry mimeType either"
+        );
+        assert!(content[1]["text"].as_str().unwrap().contains("--out"));
+    }
+
     // ---- scan + resolve: scripted FigmaApi fake ----
 
     /// Pops one scripted response per call (same pattern as
@@ -896,6 +1057,83 @@ mod tests {
                 }),
             );
         });
+    }
+
+    // ---- I-3-style collision safety (mirrors cache.rs's own test) ----
+
+    /// A row that collides on `image_key`'s hash but actually belongs to a
+    /// different `(kind, subject)` pair must read as a miss, not get
+    /// served as a different item's bytes — exactly the guarantee
+    /// `cache::lookup`'s own collision test proves for `proxy_cache`.
+    #[test]
+    fn scan_misses_on_collision_where_key_matches_but_kind_and_subject_dont() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut st = crate::open_store!(dir.path().join("db"));
+        insert_meta(&mut st, "100");
+
+        let requested_id = "1:2".to_string();
+        let key = image_key(RENDER, &requested_id, "png", 1000);
+        // Constructed directly under the exact key a render lookup for
+        // `requested_id` will compute, but tagged as a *fill* for a
+        // different subject — exactly what a real FNV-64 collision would
+        // look like, without needing to actually find one.
+        let colliding = ImageBlobRec {
+            key_hash: key.clone(),
+            kind: FILL.to_string(),
+            subject: "some-other-ref".to_string(),
+            format: "jpg".to_string(),
+            scale_milli: 1000,
+            file_version: "100".to_string(),
+            bytes: vec![9, 9, 9],
+        };
+        st.wtx(|tx| {
+            tx.upsert(&Id::ImageBlob(key), &Rec::ImageBlob(colliding));
+        });
+
+        let ids = vec![requested_id.clone()];
+        let scanned = st.rtx(|((nodes, ..), _, _, _, _, _, meta, _, _, images)| {
+            scan(&nodes, &meta, &images, &ids, "png", 1000)
+        });
+        assert!(
+            !scanned.render_hits.contains_key(&requested_id),
+            "a key-hash collision must never be served as a cache hit"
+        );
+    }
+
+    /// Same collision guarantee, the render-specific half: a row under the
+    /// right key with the *right* kind/subject but a different requested
+    /// format or scale must still read as a miss — `image_key` folds
+    /// format/scale into the hash, but a real collision could still land
+    /// two distinct `(format, scale)` requests on the same bucket.
+    #[test]
+    fn scan_render_hit_requires_matching_format_and_scale() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut st = crate::open_store!(dir.path().join("db"));
+        insert_meta(&mut st, "100");
+
+        let requested_id = "1:2".to_string();
+        let key = image_key(RENDER, &requested_id, "png", 1000);
+        let colliding = ImageBlobRec {
+            key_hash: key.clone(),
+            kind: RENDER.to_string(),
+            subject: requested_id.clone(),
+            format: "svg".to_string(), // requested "png"
+            scale_milli: 2000,         // requested 1000
+            file_version: "100".to_string(),
+            bytes: vec![9, 9, 9],
+        };
+        st.wtx(|tx| {
+            tx.upsert(&Id::ImageBlob(key), &Rec::ImageBlob(colliding));
+        });
+
+        let ids = vec![requested_id.clone()];
+        let scanned = st.rtx(|((nodes, ..), _, _, _, _, _, meta, _, _, images)| {
+            scan(&nodes, &meta, &images, &ids, "png", 1000)
+        });
+        assert!(
+            !scanned.render_hits.contains_key(&requested_id),
+            "a format/scale mismatch under the same key must never be served"
+        );
     }
 
     /// `scan` then `resolve`, exactly the two-step call every production

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod cli;
 mod dispatch;
 pub mod flatten;
 pub(crate) mod ident;
+pub mod images;
 pub(crate) mod mcp;
 pub mod model;
 mod proxy;

--- a/src/model.rs
+++ b/src/model.rs
@@ -22,9 +22,13 @@ pub enum Id {
     /// earlier in this enum would corrupt every existing store.
     ProxyCache(String),
     /// Sticky per-mirror settings row (v0.0.2 spec §4), one per store, like
-    /// [`Id::Meta`]. APPEND ONLY — see [`Id::ProxyCache`]'s note; this must
-    /// stay the last variant until the next one is appended after it.
+    /// [`Id::Meta`]. APPEND ONLY — see [`Id::ProxyCache`]'s note.
     MirrorConfig,
+    /// Cached image bytes (render or fill, v0.0.2 spec §5), keyed by
+    /// [`crate::images::image_key`]'s hash — same pattern as
+    /// [`Id::ProxyCache`]. APPEND ONLY — see that variant's note; this must
+    /// stay the last variant until the next one is appended after it.
+    ImageBlob(String),
 }
 
 /// One mirrored record; variant always matches its [`Id`] variant.
@@ -41,6 +45,8 @@ pub enum Rec {
     ProxyCache(ProxyCacheRec),
     /// See [`Id::MirrorConfig`]. APPEND ONLY — see that variant's note.
     MirrorConfig(MirrorConfigRec),
+    /// See [`Id::ImageBlob`]. APPEND ONLY — see that variant's note.
+    ImageBlob(ImageBlobRec),
 }
 
 /// One node of the document tree (children stripped from `raw`).
@@ -171,6 +177,41 @@ pub struct MirrorConfigRec {
     pub geometry: bool,
 }
 
+/// One cached image blob — a node render or a fill's referenced bytes
+/// (v0.0.2 spec §5). A hit requires `file_version` to equal the mirror's
+/// current [`FileMeta::version`], exactly like [`ProxyCacheRec`]; a
+/// version bump makes the row stale and eligible for eviction
+/// (`store::stale_image_ids` / `store::evict_stale_cache`).
+///
+/// Lives in its own append-only enum variant rather than widening an
+/// existing struct, for the same reason as [`MirrorConfigRec`] — see that
+/// type's doc comment and `CLAUDE.md`'s struct-vs-enum-append rule.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ImageBlobRec {
+    /// Hash of `kind` + `subject` + `format` + `scale_milli`; identical to
+    /// the [`Id::ImageBlob`] key ([`crate::images::image_key`]).
+    pub key_hash: String,
+    /// `"render"` (a `GET /v1/images/:key` node render) or `"fill"` (a
+    /// `GET /v1/files/:key/images` fill image, addressed by its
+    /// `imageRef` hash).
+    pub kind: String,
+    /// Node id (`kind == "render"`) or `imageRef` hash (`kind == "fill"`).
+    pub subject: String,
+    /// Requested render format (`"png"`/`"svg"`/…), or the format
+    /// inferred from a fill's download URL — informational only for
+    /// fills, since [`crate::images::image_key`] never varies a fill's
+    /// cache key by format (Figma's fills endpoint takes no format
+    /// parameter; the same `imageRef` always resolves to the same bytes).
+    pub format: String,
+    /// Requested scale × 1000 (e.g. `scale: 1.5` ⇒ `1500`); always `1000`
+    /// for fills, which aren't scale-parameterized.
+    pub scale_milli: u32,
+    /// File version this blob was fetched at.
+    pub file_version: String,
+    /// The raw image bytes.
+    pub bytes: Vec<u8>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,15 +252,36 @@ mod tests {
         assert_eq!(rec, back);
     }
 
-    /// Postcard-append safety (v0.0.2 spec §4): a store written before
+    fn sample_image_blob() -> ImageBlobRec {
+        ImageBlobRec {
+            key_hash: "abc123".into(),
+            kind: "render".into(),
+            subject: "1:2".into(),
+            format: "png".into(),
+            scale_milli: 2000,
+            file_version: "100".into(),
+            bytes: vec![0x89, b'P', b'N', b'G'],
+        }
+    }
+
+    #[test]
+    fn image_blob_rec_postcard_roundtrip() {
+        let rec = Rec::ImageBlob(sample_image_blob());
+        let bytes = postcard::to_allocvec(&rec).unwrap();
+        let back: Rec = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(rec, back);
+    }
+
+    /// Postcard-append safety (v0.0.2 spec §4 + §5): a store written before
     /// `MirrorConfig` existed encoded `Rec::ProxyCache` at variant index 7
     /// (the 8th of 8 variants, 0-indexed) — postcard's enum encoding is a
     /// leading varint variant index, one byte for fewer than 128 variants.
     /// Appending `MirrorConfig` *after* `ProxyCache` must not move that
     /// index (it would corrupt every existing cache row's discriminant on
-    /// decode), and the new variant must land at the next free index (8).
-    /// A pre-change build isn't available to literally round-trip against,
-    /// so this pins the concrete byte instead — the same guarantee the
+    /// decode), and each new variant must land at the next free index (8
+    /// for `MirrorConfig`, 9 for the later-appended `ImageBlob`). A
+    /// pre-change build isn't available to literally round-trip against,
+    /// so this pins the concrete bytes instead — the same guarantee the
     /// append-only doc comments on `Id`/`Rec` assert, made checkable.
     #[test]
     fn append_only_preserves_existing_variant_indices() {
@@ -236,6 +298,10 @@ mod tests {
         let cfg = Rec::MirrorConfig(MirrorConfigRec { geometry: true });
         let bytes = postcard::to_allocvec(&cfg).unwrap();
         assert_eq!(bytes[0], 8, "MirrorConfig is the newly appended variant");
+
+        let img = Rec::ImageBlob(sample_image_blob());
+        let bytes = postcard::to_allocvec(&img).unwrap();
+        assert_eq!(bytes[0], 9, "ImageBlob is the newly appended variant");
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -21,6 +21,10 @@ pub enum Id {
     /// ONLY: postcard encodes variant indices, so inserting a variant
     /// earlier in this enum would corrupt every existing store.
     ProxyCache(String),
+    /// Sticky per-mirror settings row (v0.0.2 spec §4), one per store, like
+    /// [`Id::Meta`]. APPEND ONLY — see [`Id::ProxyCache`]'s note; this must
+    /// stay the last variant until the next one is appended after it.
+    MirrorConfig,
 }
 
 /// One mirrored record; variant always matches its [`Id`] variant.
@@ -35,6 +39,8 @@ pub enum Rec {
     Meta(FileMeta),
     /// See [`Id::ProxyCache`]. APPEND ONLY — see that variant's note.
     ProxyCache(ProxyCacheRec),
+    /// See [`Id::MirrorConfig`]. APPEND ONLY — see that variant's note.
+    MirrorConfig(MirrorConfigRec),
 }
 
 /// One node of the document tree (children stripped from `raw`).
@@ -148,6 +154,23 @@ pub struct ProxyCacheRec {
     pub content: String,
 }
 
+/// The single sticky-config row (key [`Id::MirrorConfig`], v0.0.2 spec
+/// §4): whether pulls of this mirror should request vector geometry
+/// (`fillGeometry`/`strokeGeometry`) from Figma. An absent row (every
+/// pre-v0.0.2 store, and any store that's never been pulled with
+/// `--geometry`) means `false`.
+///
+/// This lives in its own record kind rather than as a new `FileMeta`
+/// field on purpose: postcard structs encode fields positionally, so
+/// widening `FileMeta` would silently corrupt decoding of every existing
+/// store, while an enum-variant *append* (this type, `Id::MirrorConfig`,
+/// `Rec::MirrorConfig`) is safe — see `CLAUDE.md`'s struct-vs-enum-append
+/// rule and `Id::ProxyCache`'s note.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MirrorConfigRec {
+    pub geometry: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,6 +201,41 @@ mod tests {
         let bytes = postcard::to_allocvec(&rec).unwrap();
         let back: Rec = postcard::from_bytes(&bytes).unwrap();
         assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn mirror_config_rec_postcard_roundtrip() {
+        let rec = Rec::MirrorConfig(MirrorConfigRec { geometry: true });
+        let bytes = postcard::to_allocvec(&rec).unwrap();
+        let back: Rec = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(rec, back);
+    }
+
+    /// Postcard-append safety (v0.0.2 spec §4): a store written before
+    /// `MirrorConfig` existed encoded `Rec::ProxyCache` at variant index 7
+    /// (the 8th of 8 variants, 0-indexed) — postcard's enum encoding is a
+    /// leading varint variant index, one byte for fewer than 128 variants.
+    /// Appending `MirrorConfig` *after* `ProxyCache` must not move that
+    /// index (it would corrupt every existing cache row's discriminant on
+    /// decode), and the new variant must land at the next free index (8).
+    /// A pre-change build isn't available to literally round-trip against,
+    /// so this pins the concrete byte instead — the same guarantee the
+    /// append-only doc comments on `Id`/`Rec` assert, made checkable.
+    #[test]
+    fn append_only_preserves_existing_variant_indices() {
+        let proxy = Rec::ProxyCache(ProxyCacheRec {
+            key_hash: "h".into(),
+            tool: "t".into(),
+            args_canonical: "{}".into(),
+            file_version: "1".into(),
+            content: "{}".into(),
+        });
+        let bytes = postcard::to_allocvec(&proxy).unwrap();
+        assert_eq!(bytes[0], 7, "ProxyCache's variant index must not move");
+
+        let cfg = Rec::MirrorConfig(MirrorConfigRec { geometry: true });
+        let bytes = postcard::to_allocvec(&cfg).unwrap();
+        assert_eq!(bytes[0], 8, "MirrorConfig is the newly appended variant");
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -337,7 +337,7 @@ mod tests {
         assert!(!poll);
         assert_eq!(upstream.call_count, 1);
 
-        let stored = st.rtx(|(_, _, _, _, _, _, _, cache)| {
+        let stored = st.rtx(|(_, _, _, _, _, _, _, cache, _)| {
             cache::lookup(
                 &cache,
                 "get_code",
@@ -449,7 +449,7 @@ mod tests {
         assert_eq!(value, error_result);
         assert!(!poll);
 
-        let stored = st.rtx(|(_, _, _, _, _, _, _, cache)| {
+        let stored = st.rtx(|(_, _, _, _, _, _, _, cache, _)| {
             cache::lookup(
                 &cache,
                 "get_code",

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -337,7 +337,7 @@ mod tests {
         assert!(!poll);
         assert_eq!(upstream.call_count, 1);
 
-        let stored = st.rtx(|(_, _, _, _, _, _, _, cache, _)| {
+        let stored = st.rtx(|(_, _, _, _, _, _, _, cache, _, _)| {
             cache::lookup(
                 &cache,
                 "get_code",
@@ -449,7 +449,7 @@ mod tests {
         assert_eq!(value, error_result);
         assert!(!poll);
 
-        let stored = st.rtx(|(_, _, _, _, _, _, _, cache, _)| {
+        let stored = st.rtx(|(_, _, _, _, _, _, _, cache, _, _)| {
             cache::lookup(
                 &cache,
                 "get_code",

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,7 @@
 //! One source of truth for every read answer — shared by the CLI printers
 //! and the MCP tools.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 
 use serde_json::{Value, json};
 
@@ -9,7 +9,7 @@ use fold::pipeline::terminal::search::Bm25Reader;
 use fold::pipeline::terminal::{InvertedIndexReader, MultimapReader, TableReader};
 use fold::stream::Readable;
 
-use crate::ident::normalize_node_id;
+use crate::ident::{normalize_node_id, normalize_node_ref};
 use crate::model::{
     ComponentRec, ComponentSetRec, FileMeta, NodeRec, StyleRec, VariableCollectionRec, VariableRec,
 };
@@ -17,6 +17,108 @@ use crate::model::{
 /// Read handle for the pipeline's `text` BM25 sink (its tokenizer type
 /// param makes the full type unwieldy at every call site).
 pub type TextReader<'tx, R> = Bm25Reader<'tx, R, String, fn(&str, &mut Vec<u8>)>;
+
+/// BFS the `children` index from `scope_root` (inclusive), collecting the
+/// descendant id set — the shared engine behind `--under` scoping (spec
+/// §3). Cycle-safe via the visited set, same discipline as `path`/
+/// `depth_of`'s `parent_id` walks: a corrupted store with a `children`
+/// cycle can't loop forever, it just stops re-queuing an id it's already
+/// visited. Unknown `scope_root` is the caller's job to reject (via
+/// `nodes.get` before calling this) so the error message names the right
+/// argument.
+fn scope_ids<R: Readable>(
+    children: &MultimapReader<'_, R, String, (u32, String)>,
+    scope_root: &str,
+) -> BTreeSet<String> {
+    let mut visited: BTreeSet<String> = BTreeSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+    visited.insert(scope_root.to_string());
+    queue.push_back(scope_root.to_string());
+    while let Some(current) = queue.pop_front() {
+        for (_, child_id) in children.get(&current) {
+            if visited.insert(child_id.clone()) {
+                queue.push_back(child_id);
+            }
+        }
+    }
+    visited
+}
+
+/// Resolve an optional `--under <id>` scope argument to the descendant id
+/// set it names (root inclusive), or `None` when no scope was requested.
+/// Unknown id ⇒ the standard "no node … in the mirror" error (spec §3).
+fn resolve_under<R: Readable>(
+    nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
+    under: Option<String>,
+) -> Result<Option<BTreeSet<String>>, String> {
+    match under {
+        None => Ok(None),
+        Some(raw) => {
+            let id = normalize_node_ref(&raw);
+            nodes
+                .get(&id)
+                .ok_or_else(|| format!("no node {id} in the mirror"))?;
+            Ok(Some(scope_ids(children, &id)))
+        }
+    }
+}
+
+/// One `boundVariables` binding site resolved against the variables table
+/// (spec §6): `{pointer, variable_id, variable_name, values_by_mode}` when
+/// the variable is known (imported or Enterprise-synced), else
+/// `{pointer, variable_id, source: "unresolved"}`. Never errors — an
+/// unresolved binding is a normal, expected outcome on the free plan.
+fn resolve_variable_binding<R: Readable>(
+    variables: &TableReader<'_, R, String, VariableRec>,
+    variable_collections: &TableReader<'_, R, String, VariableCollectionRec>,
+    pointer: &str,
+    variable_id: &str,
+) -> Value {
+    match variables.get(&variable_id.to_string()) {
+        Some(var) => {
+            let collection = variable_collections.get(&var.collection_id);
+            let mut values_by_mode = serde_json::Map::new();
+            for (mode_id, val_str) in &var.values_by_mode {
+                let mode_name = collection
+                    .as_ref()
+                    .and_then(|c| c.modes.iter().find(|(mid, _)| mid == mode_id))
+                    .map(|(_, name)| name.clone())
+                    .unwrap_or_else(|| mode_id.clone());
+                let val: Value = serde_json::from_str(val_str).unwrap_or(Value::Null);
+                values_by_mode.insert(mode_name, val);
+            }
+            json!({
+                "pointer": pointer,
+                "variable_id": variable_id,
+                "variable_name": var.name,
+                "values_by_mode": Value::Object(values_by_mode),
+            })
+        }
+        None => json!({
+            "pointer": pointer,
+            "variable_id": variable_id,
+            "source": "unresolved",
+        }),
+    }
+}
+
+/// `resolved_variables` array for a node's (or a style's) full set of
+/// `boundVariables` binding sites, in the sorted order `bound_variables`
+/// already carries (model.rs's determinism contract) — never re-sorted.
+fn resolved_variables<R: Readable>(
+    variables: &TableReader<'_, R, String, VariableRec>,
+    variable_collections: &TableReader<'_, R, String, VariableCollectionRec>,
+    bound_variables: &[(String, String)],
+) -> Value {
+    let arr: Vec<Value> = bound_variables
+        .iter()
+        .map(|(pointer, vid)| {
+            resolve_variable_binding(variables, variable_collections, pointer, vid)
+        })
+        .collect();
+    Value::Array(arr)
+}
 
 /// File name, version, last modified, node count.
 pub fn status<R: Readable>(
@@ -110,7 +212,7 @@ pub fn tree_nodes<R: Readable>(
     depth: Option<usize>,
 ) -> Result<TreeNode, String> {
     let start = match id {
-        Some(raw) => normalize_node_id(&raw),
+        Some(raw) => normalize_node_ref(&raw),
         None => {
             let mut docs = by_type.search(&"DOCUMENT".to_string());
             docs.sort();
@@ -137,14 +239,19 @@ pub fn tree<R: Readable>(
     Ok(tree_to_json(&t))
 }
 
-/// Full raw JSON of one node, optionally with a `children` summary array.
+/// Full raw JSON of one node, optionally with a `children` summary array
+/// and/or a `resolved_variables` annotation (spec §6) of every
+/// `boundVariables` binding site on this node.
 pub fn node<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
     children: &MultimapReader<'_, R, String, (u32, String)>,
+    variables: &TableReader<'_, R, String, VariableRec>,
+    variable_collections: &TableReader<'_, R, String, VariableCollectionRec>,
     id: String,
     with_children: bool,
+    resolve_vars: bool,
 ) -> Result<Value, String> {
-    let id = normalize_node_id(&id);
+    let id = normalize_node_ref(&id);
     let n = nodes
         .get(&id)
         .ok_or_else(|| format!("no node {id} in the mirror"))?;
@@ -166,26 +273,146 @@ pub fn node<R: Readable>(
         }
     }
 
+    if resolve_vars && let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "resolved_variables".to_string(),
+            resolved_variables(variables, variable_collections, &n.bound_variables),
+        );
+    }
+
     Ok(value)
 }
 
-/// Nodes by type, optionally within one page.
+/// Top-level raw fields a `fields` projection keeps regardless of whether
+/// they were named (spec §2): `id`/`name`/`type` because a projected node
+/// must stay identifiable. `children` isn't listed here — `raw` never
+/// carries a `children` field (flatten strips it), and [`build_subtree`]
+/// always adds it back after projection, so it survives unconditionally
+/// without needing a name-check.
+const SUBTREE_ALWAYS_FIELDS: [&str; 3] = ["id", "name", "type"];
+
+/// Project a subtree node's raw JSON object down to `fields` plus the
+/// always-kept set. Unknown field names are simply absent, not an error —
+/// spec §2's "agents probe freely" contract. A non-object `value` (should
+/// never happen for a real Figma node) passes through unchanged.
+fn project_raw_fields(mut value: Value, fields: &[String]) -> Value {
+    if let Value::Object(ref mut map) = value {
+        map.retain(|k, _| {
+            SUBTREE_ALWAYS_FIELDS.contains(&k.as_str()) || fields.iter().any(|f| f == k)
+        });
+    }
+    value
+}
+
+/// Recursive worker behind [`subtree`]: raw JSON of `n`, fields-projected,
+/// with `children` nested in child-index order and (when requested)
+/// `resolved_variables` — both inserted *after* projection so they always
+/// survive a `fields` filter, matching `id`/`name`/`type`.
+#[allow(clippy::too_many_arguments)]
+fn build_subtree<R: Readable>(
+    nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
+    variables: &TableReader<'_, R, String, VariableRec>,
+    variable_collections: &TableReader<'_, R, String, VariableCollectionRec>,
+    n: &NodeRec,
+    depth: Option<usize>,
+    fields: Option<&[String]>,
+    resolve_vars: bool,
+) -> Result<Value, String> {
+    let mut value: Value = serde_json::from_str(&n.raw).map_err(|e| e.to_string())?;
+    if let Some(fs) = fields {
+        value = project_raw_fields(value, fs);
+    }
+
+    let mut kids_json = Vec::new();
+    if depth != Some(0) {
+        let mut edges = children.get(&n.id);
+        edges.sort();
+        let next_depth = depth.map(|d| d - 1);
+        for (_, child_id) in edges {
+            if let Some(child) = nodes.get(&child_id) {
+                kids_json.push(build_subtree(
+                    nodes,
+                    children,
+                    variables,
+                    variable_collections,
+                    &child,
+                    next_depth,
+                    fields,
+                    resolve_vars,
+                )?);
+            }
+        }
+    }
+
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("children".to_string(), Value::Array(kids_json));
+        if resolve_vars {
+            obj.insert(
+                "resolved_variables".to_string(),
+                resolved_variables(variables, variable_collections, &n.bound_variables),
+            );
+        }
+    }
+
+    Ok(value)
+}
+
+/// Subtree dump rooted at `id` (spec §2): the node's full raw JSON with
+/// `children: [...]` nested recursively in child-index order, to `depth`
+/// levels (default: unlimited). `fields` projects every node to the named
+/// raw fields (`id`/`name`/`type`/`children` always survive); `None` skips
+/// projection entirely. `resolve_vars` adds a `resolved_variables`
+/// annotation (spec §6) to every node.
+#[allow(clippy::too_many_arguments)]
+pub fn subtree<R: Readable>(
+    nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
+    variables: &TableReader<'_, R, String, VariableRec>,
+    variable_collections: &TableReader<'_, R, String, VariableCollectionRec>,
+    id: String,
+    depth: Option<usize>,
+    fields: Option<&[String]>,
+    resolve_vars: bool,
+) -> Result<Value, String> {
+    let id = normalize_node_ref(&id);
+    let root = nodes
+        .get(&id)
+        .ok_or_else(|| format!("no node {id} in the mirror"))?;
+    build_subtree(
+        nodes,
+        children,
+        variables,
+        variable_collections,
+        &root,
+        depth,
+        fields,
+        resolve_vars,
+    )
+}
+
+/// Nodes by type, optionally within one page and/or scoped to `under`'s
+/// subtree (spec §3: intersects with the page filter).
 pub fn find<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
     by_type: &InvertedIndexReader<'_, R, String, String>,
     node_type: String,
     page: Option<String>,
+    under: Option<String>,
 ) -> Result<Value, String> {
     // Figma node types are stored uppercase; normalize so `--type frame`
     // matches the same as `--type FRAME`.
     let mut ids = by_type.search(&node_type.to_uppercase());
     ids.sort();
     let page = page.as_deref().map(normalize_node_id);
+    let scope = resolve_under(nodes, children, under)?;
 
     let mut rows: Vec<(String, String, String)> = ids
         .into_iter()
         .filter_map(|id| nodes.get(&id))
         .filter(|n| page.as_deref().is_none_or(|p| n.page_id == p))
+        .filter(|n| scope.as_ref().is_none_or(|s| s.contains(&n.id)))
         .map(|n| (n.id, n.name, n.page_id))
         .collect();
     rows.sort();
@@ -197,17 +424,26 @@ pub fn find<R: Readable>(
     Ok(Value::Array(arr))
 }
 
-/// BM25 search over layer names and text content.
+/// BM25 search over layer names and text content, optionally scoped to
+/// `under`'s subtree (spec §3). `limit` still caps the BM25 index's own
+/// top-N *before* the scope filter runs (that ranking, not this filter, is
+/// the expensive part) — a scoped call can return fewer than `limit` hits
+/// when some of the top matches fall outside `under`, same as every other
+/// filter here composing with a cap.
 pub fn search<R: Readable>(
     text: &TextReader<'_, R>,
     nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
     query: &str,
     limit: usize,
+    under: Option<String>,
 ) -> Result<Value, String> {
+    let scope = resolve_under(nodes, children, under)?;
     // BM25's own ranking order is deterministic; keep it (do not re-sort).
     let hits = text.search(query, limit);
     let rows: Vec<Value> = hits
         .iter()
+        .filter(|hit| scope.as_ref().is_none_or(|s| s.contains(&hit.val)))
         .filter_map(|hit| {
             let node = nodes.get(&hit.val)?;
             let snippet = node
@@ -281,7 +517,7 @@ pub fn instances<R: Readable>(
     instances_of: &InvertedIndexReader<'_, R, String, String>,
     target: &str,
 ) -> Result<Value, String> {
-    let target = normalize_node_id(target);
+    let target = normalize_node_ref(target);
     let component_ids = resolve_component_ids(components, component_sets, &target);
 
     let mut instance_ids: BTreeSet<String> = BTreeSet::new();
@@ -342,12 +578,20 @@ pub fn components<R: Readable>(
 }
 
 /// Styles with usage counts; `values` derives definitions from consumers.
+/// `resolve_vars` (with `values`) adds a `resolved_variables` annotation
+/// (spec §6) of the variable bindings under that definition's own raw-JSON
+/// pointer prefix (e.g. a FILL style's bindings live under `/fills`) — a
+/// no-op without `values`, since there's no definition to annotate.
+#[allow(clippy::too_many_arguments)]
 pub fn styles<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
     styles: &TableReader<'_, R, String, StyleRec>,
     styled_by: &InvertedIndexReader<'_, R, String, String>,
+    variables: &TableReader<'_, R, String, VariableRec>,
+    variable_collections: &TableReader<'_, R, String, VariableCollectionRec>,
     style_type: Option<String>,
     values: bool,
+    resolve_vars: bool,
 ) -> Result<Value, String> {
     let mut rows: Vec<(String, StyleRec)> = styles.iter().collect();
     rows.sort_by(|a, b| a.0.cmp(&b.0));
@@ -368,12 +612,27 @@ pub fn styles<R: Readable>(
                 "uses": consumers.len(),
             });
             if values {
-                let value = consumers
-                    .first()
-                    .and_then(|nid| nodes.get(nid))
+                let consumer = consumers.first().and_then(|nid| nodes.get(nid));
+                let value = consumer
+                    .as_ref()
                     .and_then(|n| crate::vars::style_value_from_consumer(&s.style_type, &n.raw))
                     .unwrap_or(Value::Null);
                 obj["value"] = value;
+
+                if resolve_vars {
+                    let prefix = crate::vars::style_value_pointer(&s.style_type);
+                    let bound: Vec<(String, String)> = consumer
+                        .map(|n| {
+                            n.bound_variables
+                                .iter()
+                                .filter(|(p, _)| prefix.is_some_and(|pre| p.starts_with(pre)))
+                                .cloned()
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    obj["resolved_variables"] =
+                        resolved_variables(variables, variable_collections, &bound);
+                }
             }
             obj
         })
@@ -542,7 +801,7 @@ pub fn path<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
     id: String,
 ) -> Result<Value, String> {
-    let id = normalize_node_id(&id);
+    let id = normalize_node_ref(&id);
     let mut chain: Vec<NodeRec> = Vec::new();
     let mut visited: BTreeSet<String> = BTreeSet::new();
     let mut current = id.clone();
@@ -570,20 +829,25 @@ pub fn path<R: Readable>(
 }
 
 /// Every TEXT node's `(id, characters, page_id)`, optionally scoped to one
-/// page, sorted by id.
+/// page and/or `under`'s subtree (spec §3: intersects with the page
+/// filter), sorted by id.
 pub fn text<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
     by_type: &InvertedIndexReader<'_, R, String, String>,
     page: Option<String>,
+    under: Option<String>,
 ) -> Result<Value, String> {
     let mut ids = by_type.search(&"TEXT".to_string());
     ids.sort();
     let page = page.as_deref().map(normalize_node_id);
+    let scope = resolve_under(nodes, children, under)?;
 
     let mut rows: Vec<(String, String, String)> = ids
         .into_iter()
         .filter_map(|id| nodes.get(&id))
         .filter(|n| page.as_deref().is_none_or(|p| n.page_id == p))
+        .filter(|n| scope.as_ref().is_none_or(|s| s.contains(&n.id)))
         .map(|n| (n.id, n.text.clone().unwrap_or_default(), n.page_id))
         .collect();
     rows.sort();
@@ -598,13 +862,16 @@ pub fn text<R: Readable>(
 }
 
 /// Nodes whose `raw` JSON matches an RFC 6901 pointer, optionally by value
-/// and/or scoped to one page. Rows `[{id, name, type, page_id, value}]`,
+/// and/or scoped to one page and/or `under`'s subtree (spec §3: intersects
+/// with the page filter). Rows `[{id, name, type, page_id, value}]`,
 /// sorted by id.
 pub fn where_<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
+    children: &MultimapReader<'_, R, String, (u32, String)>,
     pointer: &str,
     equals: Option<Value>,
     page: Option<String>,
+    under: Option<String>,
 ) -> Result<Value, String> {
     if !pointer.starts_with('/') {
         return Err(format!(
@@ -612,10 +879,14 @@ pub fn where_<R: Readable>(
         ));
     }
     let page = page.as_deref().map(normalize_node_id);
+    let scope = resolve_under(nodes, children, under)?;
 
     let mut rows: Vec<(String, String, String, String, Value)> = Vec::new();
     for (_, n) in nodes.iter() {
         if !page.as_deref().is_none_or(|p| n.page_id == p) {
+            continue;
+        }
+        if !scope.as_ref().is_none_or(|s| s.contains(&n.id)) {
             continue;
         }
         let raw: Value = serde_json::from_str(&n.raw).map_err(|e| e.to_string())?;

--- a/src/query.rs
+++ b/src/query.rs
@@ -9,7 +9,7 @@ use fold::pipeline::terminal::search::Bm25Reader;
 use fold::pipeline::terminal::{InvertedIndexReader, MultimapReader, TableReader};
 use fold::stream::Readable;
 
-use crate::ident::{normalize_node_id, normalize_node_ref};
+use crate::ident::normalize_node_ref;
 use crate::model::{
     ComponentRec, ComponentSetRec, FileMeta, NodeRec, StyleRec, VariableCollectionRec, VariableRec,
 };
@@ -392,7 +392,9 @@ pub fn subtree<R: Readable>(
 }
 
 /// Nodes by type, optionally within one page and/or scoped to `under`'s
-/// subtree (spec §3: intersects with the page filter).
+/// subtree (spec §3: intersects with the page filter). `page` and `under`
+/// both accept a full Figma URL (spec §2b), same as any other node-id
+/// argument.
 pub fn find<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
     children: &MultimapReader<'_, R, String, (u32, String)>,
@@ -405,7 +407,7 @@ pub fn find<R: Readable>(
     // matches the same as `--type FRAME`.
     let mut ids = by_type.search(&node_type.to_uppercase());
     ids.sort();
-    let page = page.as_deref().map(normalize_node_id);
+    let page = page.as_deref().map(normalize_node_ref);
     let scope = resolve_under(nodes, children, under)?;
 
     let mut rows: Vec<(String, String, String)> = ids
@@ -425,11 +427,14 @@ pub fn find<R: Readable>(
 }
 
 /// BM25 search over layer names and text content, optionally scoped to
-/// `under`'s subtree (spec §3). `limit` still caps the BM25 index's own
-/// top-N *before* the scope filter runs (that ranking, not this filter, is
-/// the expensive part) — a scoped call can return fewer than `limit` hits
-/// when some of the top matches fall outside `under`, same as every other
-/// filter here composing with a cap.
+/// `under`'s subtree (spec §3). Scoped calls rank the *entire* matching
+/// corpus before filtering: `Bm25Reader::search` already scores every
+/// matching document internally regardless of `limit` (its own `limit`
+/// only truncates the final sorted list), so passing an effectively
+/// unlimited `limit` here isn't a more expensive query — it just skips
+/// that final truncation until after the scope filter runs, so an
+/// out-of-scope top-k match can't crowd an in-scope one out of the
+/// response. Unscoped calls keep the direct top-`limit` path unchanged.
 pub fn search<R: Readable>(
     text: &TextReader<'_, R>,
     nodes: &TableReader<'_, R, String, NodeRec>,
@@ -440,10 +445,12 @@ pub fn search<R: Readable>(
 ) -> Result<Value, String> {
     let scope = resolve_under(nodes, children, under)?;
     // BM25's own ranking order is deterministic; keep it (do not re-sort).
-    let hits = text.search(query, limit);
+    let search_limit = if scope.is_some() { usize::MAX } else { limit };
+    let hits = text.search(query, search_limit);
     let rows: Vec<Value> = hits
         .iter()
         .filter(|hit| scope.as_ref().is_none_or(|s| s.contains(&hit.val)))
+        .take(limit)
         .filter_map(|hit| {
             let node = nodes.get(&hit.val)?;
             let snippet = node
@@ -830,7 +837,8 @@ pub fn path<R: Readable>(
 
 /// Every TEXT node's `(id, characters, page_id)`, optionally scoped to one
 /// page and/or `under`'s subtree (spec §3: intersects with the page
-/// filter), sorted by id.
+/// filter), sorted by id. `page` and `under` both accept a full Figma URL
+/// (spec §2b), same as any other node-id argument.
 pub fn text<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
     children: &MultimapReader<'_, R, String, (u32, String)>,
@@ -840,7 +848,7 @@ pub fn text<R: Readable>(
 ) -> Result<Value, String> {
     let mut ids = by_type.search(&"TEXT".to_string());
     ids.sort();
-    let page = page.as_deref().map(normalize_node_id);
+    let page = page.as_deref().map(normalize_node_ref);
     let scope = resolve_under(nodes, children, under)?;
 
     let mut rows: Vec<(String, String, String)> = ids
@@ -864,7 +872,8 @@ pub fn text<R: Readable>(
 /// Nodes whose `raw` JSON matches an RFC 6901 pointer, optionally by value
 /// and/or scoped to one page and/or `under`'s subtree (spec §3: intersects
 /// with the page filter). Rows `[{id, name, type, page_id, value}]`,
-/// sorted by id.
+/// sorted by id. `page` and `under` both accept a full Figma URL (spec
+/// §2b), same as any other node-id argument.
 pub fn where_<R: Readable>(
     nodes: &TableReader<'_, R, String, NodeRec>,
     children: &MultimapReader<'_, R, String, (u32, String)>,
@@ -878,7 +887,7 @@ pub fn where_<R: Readable>(
             "pointer must be an RFC 6901 pointer starting with '/': {pointer}"
         ));
     }
-    let page = page.as_deref().map(normalize_node_id);
+    let page = page.as_deref().map(normalize_node_ref);
     let scope = resolve_under(nodes, children, under)?;
 
     let mut rows: Vec<(String, String, String, String, Value)> = Vec::new();

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -898,6 +898,21 @@ fn handle_tool_call(
                     e.message
                 })?;
 
+        if name == "figmog_images" {
+            // v0.0.2 spec §5: never automatic, and this is the only place
+            // that reaches `FileSession::images` — no other call site
+            // wires it in. `resolve` already spends this session's cache
+            // and, on a miss, its Figma API budget; a pull failure has no
+            // analog here (images doesn't pull the file), so unlike
+            // `figmog_sync`/`figmog_open` this never touches
+            // `next_deadline`.
+            let ids = dispatch::require_str_array(args, "ids")?;
+            let format = args.get("format").and_then(Value::as_str).unwrap_or("png");
+            let scale = dispatch::arg_f64(args, "scale");
+            let items = (session.images)(&ids, format, scale)?;
+            return Ok(ToolOutput::Raw(crate::images::to_mcp_content(&items)));
+        }
+
         if name == "figmog_sync" {
             // `resolve` already spent this call's one pull if the session
             // was new/unmirrored — skip the redundant second Tier-1 pull
@@ -1001,10 +1016,10 @@ mod tests {
         })]);
         let (tools, dropped) = proxy::merge_registry(local_registry(), upstream.tools());
         assert!(dropped.is_empty());
-        assert_eq!(tools.len(), 21);
-        assert!(tools[..20].iter().all(|t| t.name.starts_with("figmog_")));
-        assert_eq!(tools[20].name, "get_design_context");
-        assert!(tools[20].description.starts_with("[via Figma desktop] "));
+        assert_eq!(tools.len(), 22);
+        assert!(tools[..21].iter().all(|t| t.name.starts_with("figmog_")));
+        assert_eq!(tools[21].name, "get_design_context");
+        assert!(tools[21].description.starts_with("[via Figma desktop] "));
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -33,7 +33,7 @@
 //!
 //! **v3 (build design §12):** unless `--no-upstream`, figmog also probes
 //! Figma's native desktop MCP server at startup and becomes the *only*
-//! Figma MCP an agent needs — `tools/list` merges the 20 local `figmog_*`
+//! Figma MCP an agent needs — `tools/list` merges the 21 local `figmog_*`
 //! tools with every upstream tool verbatim (`proxy::merge_registry`), and
 //! `tools/call` routes by the namespace rule (`proxy::is_local_tool`).
 //! Upstream routing is global, not per-session: the desktop server serves

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -44,7 +44,7 @@
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -169,12 +169,24 @@ const SOCKET_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 /// root" error on [`StaleProbe::Owned`] (`run_serve` surfaces this as an
 /// ordinary `Err`, which `cli::run`'s top-level handler turns into the
 /// standard `{"error": ...}` exit-1 JSON — spec §1: "exit with a clean JSON
-/// error"). Sets the socket file's mode to 0600 after binding (spec §1:
-/// "auth on the socket" is explicitly a non-goal — filesystem permissions
-/// are the boundary).
+/// error"). Sets the socket file's mode to 0600 after binding, and
+/// `figmog_root` itself to 0700 (review m4): macOS in particular ignores a
+/// unix-domain socket *file's* mode for connect permission checks — the
+/// containing directory's mode is the real access boundary there, so
+/// tightening only the socket file would be closer to cosmetic than
+/// enforced on that platform. `figmog_root` may already exist (a prior
+/// session's store, or a re-bind) — the mode is set unconditionally either
+/// way, since every path that reaches this point is this process's own
+/// root to run as its owner sees fit.
 fn bind_socket(figmog_root: &Path) -> Result<(UnixListener, PathBuf), String> {
     std::fs::create_dir_all(figmog_root)
         .map_err(|e| format!("creating {}: {e}", figmog_root.display()))?;
+    let mut dir_perms = std::fs::metadata(figmog_root)
+        .map_err(|e| e.to_string())?
+        .permissions();
+    dir_perms.set_mode(0o700);
+    std::fs::set_permissions(figmog_root, dir_perms).map_err(|e| e.to_string())?;
+
     let path = socket_path(figmog_root);
 
     if path.exists() {
@@ -203,30 +215,125 @@ fn bind_socket(figmog_root: &Path) -> Result<(UnixListener, PathBuf), String> {
     Ok((listener, path))
 }
 
-/// Unlinks the control-plane socket file on drop. Every one of
-/// `run_serve`'s return points — a clean stdin-EOF exit, a watch-loop
-/// disconnect, a future early error after the socket was bound — drops
-/// this implicitly (it's held in a local binding for the rest of the
-/// function's scope), so "unlinked on clean exit" (spec §1) is structural
-/// rather than a set of hand-maintained cleanup calls at each return site.
-/// Never constructed for a probe that found another serve owning the root:
-/// [`bind_socket`] returns `Err` before creating one in that case, and that
-/// socket file is not this process's to remove.
-struct SocketGuard(PathBuf);
+/// Unlinks the control-plane socket file on drop — but only if the file at
+/// `path` is still the *same inode* this process bound (review m3): a
+/// racer, or an operator manually `rm`-ing and recreating the path while
+/// this process ran, could otherwise cause this guard to delete a live
+/// socket that isn't this process's own. `(dev, ino)` is recorded right
+/// after a successful bind and re-checked at drop time via a fresh
+/// `stat` — cheap, and the only reliable way to answer "is this still my
+/// file" on a plain path (there's no unlink-by-fd primitive for a named
+/// unix socket). A `stat` failure at drop time (the path is already gone)
+/// is treated as nothing-to-do, not an error.
+///
+/// Every one of `run_serve`'s return points — a clean stdin-EOF exit, a
+/// watch-loop disconnect, a future early error after the socket was bound
+/// — drops this implicitly (it's held in a local binding for the rest of
+/// the function's scope), so "unlinked on clean exit" (spec §1) is
+/// structural rather than a set of hand-maintained cleanup calls at each
+/// return site. Never constructed for a probe that found another serve
+/// owning the root: [`bind_socket`] returns `Err` before creating one in
+/// that case, and that socket file is not this process's to remove.
+struct SocketGuard {
+    path: PathBuf,
+    dev: u64,
+    ino: u64,
+}
+
+impl SocketGuard {
+    fn new(path: PathBuf) -> Result<Self, String> {
+        let meta = std::fs::metadata(&path).map_err(|e| e.to_string())?;
+        Ok(SocketGuard {
+            path,
+            dev: meta.dev(),
+            ino: meta.ino(),
+        })
+    }
+}
 
 impl Drop for SocketGuard {
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.0);
+        if let Ok(meta) = std::fs::metadata(&self.path)
+            && meta.dev() == self.dev
+            && meta.ino() == self.ino
+        {
+            let _ = std::fs::remove_file(&self.path);
+        }
     }
+}
+
+/// A single frame's hard ceiling (review m4): a client sending more than
+/// this without a newline is misbehaving (or hostile) and is disconnected
+/// rather than let grow this connection's read buffer without bound. Any
+/// real figmog request/response — including a large `figmog_subtree` dump
+/// — is orders of magnitude smaller than this.
+const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
+
+/// Generous but bounded: a socket client that never reads what serve
+/// writes back (accidentally or maliciously) must not be able to stall
+/// this connection's response forever (review I1); well-behaved clients
+/// (the CLI's own `cli::socket`, any well-formed automation) read
+/// promptly and never come close to this. Set once per connection, at
+/// accept time, on a handle that's `dup()`-shared with every later
+/// `try_clone()` of the same connection (a unix-domain socket's send
+/// timeout is a property of the underlying OS socket, not of any one
+/// process-side handle to it), so [`write_socket_response`]'s later clones
+/// inherit it automatically.
+const SOCKET_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Read one newline-delimited frame from `reader`, capped at
+/// [`MAX_FRAME_BYTES`] (review m4). `Ok(None)` on a clean EOF with no
+/// partial data; `Err` on an oversized frame (no newline found within the
+/// cap) or any underlying I/O error — both mean "disconnect this
+/// connection", exactly like every other read failure in
+/// [`spawn_socket_acceptor`].
+fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<String>> {
+    let mut buf = Vec::new();
+    // Driven directly off `fill_buf`/`consume` rather than `Take` wrapping
+    // `read_until`: a chunk can (and, with a client that pipelines several
+    // frames back-to-back, will) contain bytes past the newline — consuming
+    // only up through it, never the whole chunk, is what leaves the rest
+    // buffered for the *next* call to pick up as the start of the next
+    // frame, instead of dropping it.
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            break; // clean EOF
+        }
+        if let Some(pos) = available.iter().position(|&b| b == b'\n') {
+            buf.extend_from_slice(&available[..=pos]);
+            reader.consume(pos + 1);
+            break;
+        }
+        buf.extend_from_slice(available);
+        let consumed = available.len();
+        reader.consume(consumed);
+        if buf.len() > MAX_FRAME_BYTES {
+            return Err(std::io::Error::other(format!(
+                "frame exceeds {MAX_FRAME_BYTES} bytes with no newline"
+            )));
+        }
+    }
+    if buf.is_empty() {
+        return Ok(None);
+    }
+    while matches!(buf.last(), Some(b'\n' | b'\r')) {
+        buf.pop();
+    }
+    String::from_utf8(buf)
+        .map(Some)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
 }
 
 /// Accept loop for the control-plane socket, on its own thread: each
 /// connection gets its own reader thread forwarding newline-delimited
-/// frames into `tx` tagged with a fresh connection id, with its write half
-/// stored in `registry` first (so a request that arrives and is answered
-/// before the *next* line is even read still has somewhere to route its
-/// response). An accept or clone failure for one connection is skipped
-/// rather than tearing down the whole listener — a transient per-connection
+/// frames (bounded per [`read_bounded_line`]) into `tx` tagged with a
+/// fresh connection id, with its write half — a non-blocking-forever send
+/// timeout applied ([`SOCKET_WRITE_TIMEOUT`]) — stored in `registry` first
+/// (so a request that arrives and is answered before the *next* line is
+/// even read still has somewhere to route its response). An accept, clone,
+/// or timeout-configuration failure for one connection is skipped rather
+/// than tearing down the whole listener — a transient per-connection
 /// hiccup shouldn't take the control plane down.
 fn spawn_socket_acceptor(
     listener: UnixListener,
@@ -240,16 +347,23 @@ fn spawn_socket_acceptor(
             let Ok(write_half) = stream.try_clone() else {
                 continue;
             };
+            if write_half
+                .set_write_timeout(Some(SOCKET_WRITE_TIMEOUT))
+                .is_err()
+            {
+                continue;
+            }
             let conn_id = next_id.fetch_add(1, Ordering::Relaxed);
             registry.lock().unwrap().insert(conn_id, write_half);
 
             let tx = tx.clone();
             let registry = registry.clone();
             std::thread::spawn(move || {
-                let reader = BufReader::new(stream);
-                for line in reader.lines() {
-                    match line {
-                        Ok(l) => {
+                let mut reader = BufReader::new(stream);
+                loop {
+                    match read_bounded_line(&mut reader) {
+                        Ok(None) => break,
+                        Ok(Some(l)) => {
                             if tx.send(Incoming::Socket(conn_id, l)).is_err() {
                                 break;
                             }
@@ -272,17 +386,32 @@ fn spawn_socket_acceptor(
 /// thread already removed the entry) simply has nothing to write to,
 /// matching every other "vanished client" path in this file: the response
 /// is dropped, not a panic and not a wedged loop. A write failure (the
-/// connection died between registration and this write) removes the now-
-/// dead entry too, so a later response for the same id doesn't retry a
-/// broken pipe.
+/// connection died, or [`SOCKET_WRITE_TIMEOUT`] elapsed against a
+/// non-reading client) removes the now-dead entry too, so a later response
+/// for the same id doesn't retry a broken pipe.
+///
+/// Review I1: the actual (bounded, per [`SOCKET_WRITE_TIMEOUT`]) write
+/// happens on a handle cloned *out from behind* the registry lock — cloning
+/// a `UnixStream` is a cheap `dup()`, not I/O — rather than while holding
+/// it. Holding the lock across a blocking write would stall every other
+/// connection's registry bookkeeping (a new connection's accept-time
+/// `insert`, another connection's disconnect-time `remove`) behind however
+/// long this one write takes to time out, on top of the (unavoidable,
+/// single-threaded-loop) delay to every other queued message this causes
+/// regardless.
 fn write_socket_response(registry: &ConnRegistry, conn_id: u64, resp: &Value) {
-    let mut reg = registry.lock().unwrap();
-    let Some(stream) = reg.get_mut(&conn_id) else {
-        return;
+    let stream = {
+        let reg = registry.lock().unwrap();
+        match reg.get(&conn_id).and_then(|s| s.try_clone().ok()) {
+            Some(s) => s,
+            None => return,
+        }
     };
+
     let text = resp.to_string();
-    if writeln!(stream, "{text}").is_err() || stream.flush().is_err() {
-        reg.remove(&conn_id);
+    let ok = writeln!(&stream, "{text}").is_ok() && (&stream).flush().is_ok();
+    if !ok {
+        registry.lock().unwrap().remove(&conn_id);
     }
 }
 
@@ -335,8 +464,9 @@ pub(crate) fn run_serve(
         None
     } else {
         let (listener, path) = bind_socket(&figmog_root)?;
+        let guard = SocketGuard::new(path)?;
         spawn_socket_acceptor(listener, tx.clone(), registry.clone());
-        Some(SocketGuard(path))
+        Some(guard)
     };
 
     // Reader thread: stdin lines -> mpsc, tagged `Incoming::Stdio` (see
@@ -1050,5 +1180,176 @@ mod tests {
 
         let (listener, _path) = bind_socket(&root).expect("stale file should be reclaimed");
         drop(listener);
+    }
+
+    #[test]
+    fn bind_socket_sets_the_root_dir_mode_to_0700() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        let (listener, _path) = bind_socket(&root).unwrap();
+        let mode = std::fs::metadata(&root).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "figmog-root should be tightened to 0700");
+        drop(listener);
+    }
+
+    // ---- review fix round: C1/C2/m1-m6 ----
+
+    #[test]
+    fn socket_guard_does_not_unlink_a_file_replaced_at_the_same_path() {
+        // Simulates a racer, or an operator manually `rm`-ing and
+        // recreating the socket path while serve is still running (m3):
+        // the guard must check the file is still the *inode* it bound, not
+        // just that "something" exists at the path, before removing it.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        let (listener, path) = bind_socket(&root).unwrap();
+        let guard = SocketGuard::new(path.clone()).unwrap();
+        drop(listener);
+
+        std::fs::remove_file(&path).unwrap();
+        std::fs::write(&path, b"someone else's file now").unwrap();
+
+        drop(guard);
+
+        assert!(
+            path.exists(),
+            "the guard must not remove a file it didn't itself create"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "someone else's file now"
+        );
+    }
+
+    #[test]
+    fn socket_guard_unlinks_its_own_untouched_socket_file() {
+        // The ordinary case, pinned alongside the "don't touch a replaced
+        // file" regression above so the two behaviors stay in view
+        // together.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        let (listener, path) = bind_socket(&root).unwrap();
+        let guard = SocketGuard::new(path.clone()).unwrap();
+        drop(listener);
+
+        drop(guard);
+
+        assert!(
+            !path.exists(),
+            "the guard should remove its own socket file"
+        );
+    }
+
+    #[test]
+    fn read_bounded_line_returns_ok_none_on_clean_eof() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let client = UnixStream::connect(&path).unwrap();
+        let (server_side, _) = listener.accept().unwrap();
+        drop(client); // EOF from the server's read side, no data ever sent.
+
+        let mut reader = BufReader::new(server_side);
+        assert_eq!(read_bounded_line(&mut reader).unwrap(), None);
+    }
+
+    #[test]
+    fn read_bounded_line_splits_multiple_pipelined_frames_from_one_chunk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let mut client = UnixStream::connect(&path).unwrap();
+        let (server_side, _) = listener.accept().unwrap();
+
+        // Two frames written in one `write_all` call, arriving as (very
+        // likely) one chunk from the reader's perspective — proving
+        // `read_bounded_line` only consumes up through the first newline,
+        // leaving the second frame's bytes buffered for the next call
+        // rather than dropping them.
+        client.write_all(b"first\nsecond\n").unwrap();
+
+        let mut reader = BufReader::new(server_side);
+        assert_eq!(
+            read_bounded_line(&mut reader).unwrap(),
+            Some("first".to_string())
+        );
+        assert_eq!(
+            read_bounded_line(&mut reader).unwrap(),
+            Some("second".to_string())
+        );
+    }
+
+    #[test]
+    fn read_bounded_line_disconnects_on_an_oversized_frame() {
+        // review m4: a line with no newline that exceeds `MAX_FRAME_BYTES`
+        // must error (disconnect the connection) rather than growing the
+        // buffer without bound.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let mut client = UnixStream::connect(&path).unwrap();
+        let (server_side, _) = listener.accept().unwrap();
+
+        let oversized = vec![b'a'; MAX_FRAME_BYTES + 1];
+        let writer = std::thread::spawn(move || {
+            // Never completes the frame with a newline — the reader must
+            // give up once the cap is exceeded, not once EOF arrives.
+            let _ = client.write_all(&oversized);
+        });
+
+        let mut reader = BufReader::new(server_side);
+        let result = read_bounded_line(&mut reader);
+        assert!(
+            result.is_err(),
+            "an oversized frame should error, not block forever collecting it"
+        );
+
+        let _ = writer.join();
+    }
+
+    #[test]
+    fn write_socket_response_disconnects_a_non_reading_client_within_a_bounded_time() {
+        // review I1: a client that never drains what serve writes back
+        // must not be able to hang `write_socket_response` (and therefore
+        // the single-threaded main loop) forever. A short write timeout —
+        // independent of the production `SOCKET_WRITE_TIMEOUT`, which
+        // stays generous for real clients — proves the *mechanism*
+        // (bounded write ⇒ disconnect ⇒ registry cleanup) without waiting
+        // out the production timeout in a unit test.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let _client = UnixStream::connect(&path).unwrap(); // never read from
+        let (server_side, _) = listener.accept().unwrap();
+        server_side
+            .set_write_timeout(Some(Duration::from_millis(200)))
+            .unwrap();
+
+        let registry: ConnRegistry = Arc::new(Mutex::new(HashMap::new()));
+        registry.lock().unwrap().insert(1, server_side);
+
+        // A sizeable payload, written repeatedly with nothing ever
+        // draining the client's receive buffer: the OS socket buffer WILL
+        // fill eventually (its exact size varies by platform, so this
+        // doesn't assume a specific threshold) and a subsequent write
+        // times out. Bounded overall by the loop's own deadline — if
+        // `write_socket_response` ever blocked indefinitely (the pre-fix
+        // behavior), this loop would hang the test past that deadline
+        // instead of completing.
+        let big = json!({"padding": "x".repeat(64 * 1024)});
+        let start = Instant::now();
+        while registry.lock().unwrap().contains_key(&1) && start.elapsed() < Duration::from_secs(10)
+        {
+            write_socket_response(&registry, 1, &big);
+        }
+
+        assert!(
+            !registry.lock().unwrap().contains_key(&1),
+            "a non-reading client's connection should eventually be dropped, not held forever"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "write_socket_response must not block indefinitely on a non-reading client"
+        );
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -42,9 +42,14 @@
 //! re-probe: an unreachable upstream at startup means local-only tools
 //! for the life of the process.
 
-use std::io::{BufRead, Write};
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
@@ -80,6 +85,207 @@ fn clamp_interval(interval: u64) -> Duration {
     Duration::from_secs(interval.min(MAX_INTERVAL_SECS))
 }
 
+// ---- unix-socket control plane (v0.0.2 spec §1) ----
+//
+// `figmog serve` additionally listens on `<figmog-root>/serve.sock`: a
+// listener thread accepts connections, and each connection's own reader
+// thread forwards newline-delimited JSON-RPC frames into the *same* `mpsc`
+// channel the stdin reader already feeds — tagged with a connection id
+// (`Incoming::Socket`) so the single-threaded main loop below can route
+// each response back to the connection that asked for it. The store is
+// still only ever touched from the main loop; socket traffic, stdio
+// frames, and watch ticks all interleave through one `recv`/`recv_timeout`
+// exactly as they always have.
+
+/// One message the serve loop can receive from either its stdin reader
+/// thread or a socket connection's reader thread.
+#[derive(Debug)]
+enum Incoming {
+    /// One line of MCP stdio input.
+    Stdio(String),
+    /// Stdin hit EOF (or a read error): the reader thread is done and the
+    /// loop should exit. An explicit sentinel — rather than relying on
+    /// every `tx` clone being dropped, the pre-socket exit signal — because
+    /// once socket connections hold their own long-lived `tx` clones, the
+    /// channel no longer reliably disconnects just because stdin closed.
+    StdinClosed,
+    /// One line from socket connection `conn_id`.
+    Socket(u64, String),
+}
+
+/// Registry of a socket connection's write half, keyed by connection id —
+/// the main loop's only way to route a response back to the connection
+/// that asked for it (its own thread only ever *reads*; writing back
+/// happens from the main loop, which is the only place a `ToolHandler` may
+/// touch the store). An entry is removed the moment its reader thread ends
+/// (EOF or any read error — see [`spawn_socket_acceptor`]), so a client
+/// that vanishes mid-request simply has no entry left to write a response
+/// to by the time one's ready.
+type ConnRegistry = Arc<Mutex<HashMap<u64, UnixStream>>>;
+
+/// `<figmog_root>/serve.sock` — must match `cli::socket`'s own derivation
+/// exactly, since that's how the CLI finds this process.
+pub(crate) fn socket_path(figmog_root: &Path) -> PathBuf {
+    figmog_root.join("serve.sock")
+}
+
+/// Outcome of probing a pre-existing socket file at startup (spec §1).
+#[derive(Debug, PartialEq, Eq)]
+enum StaleProbe {
+    /// A connect succeeded: some other process is actively listening — this
+    /// instance must not touch the file.
+    Owned,
+    /// A connect failed: nothing is actually listening (a leftover file
+    /// from an unclean exit, or garbage that was never a socket at all) —
+    /// safe to unlink and rebind.
+    Stale,
+}
+
+/// Pure classification of a connect attempt against a pre-existing socket
+/// path, split from the actual `UnixStream::connect` call so the decision
+/// itself is unit-testable without a real socket. Spec §1 only names the
+/// two outcomes that matter in practice — refused (stale) vs. success
+/// (owned) — but *any* connect failure is treated as stale: a path that
+/// exists but isn't a live listening socket at all (garbage left by
+/// something else, or a filesystem error) means this instance can't reach
+/// a live owner through it either way, so it's safe to reclaim.
+fn classify_probe(connect_result: std::io::Result<()>) -> StaleProbe {
+    match connect_result {
+        Ok(()) => StaleProbe::Owned,
+        Err(_) => StaleProbe::Stale,
+    }
+}
+
+/// Generous but bounded: probing a pre-existing socket should resolve
+/// near-instantly (either the connect succeeds against a live listener or
+/// fails against a dead one) — this only guards against a pathological
+/// hang on a socket that accepts but never proceeds.
+const SOCKET_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Bind the control-plane socket at `<figmog_root>/serve.sock`, handling
+/// the startup stale-probe (spec §1): no file yet ⇒ bind directly; a file
+/// present ⇒ probe it via [`classify_probe`], unlinking and rebinding on
+/// [`StaleProbe::Stale`] or returning the clean "another serve owns this
+/// root" error on [`StaleProbe::Owned`] (`run_serve` surfaces this as an
+/// ordinary `Err`, which `cli::run`'s top-level handler turns into the
+/// standard `{"error": ...}` exit-1 JSON — spec §1: "exit with a clean JSON
+/// error"). Sets the socket file's mode to 0600 after binding (spec §1:
+/// "auth on the socket" is explicitly a non-goal — filesystem permissions
+/// are the boundary).
+fn bind_socket(figmog_root: &Path) -> Result<(UnixListener, PathBuf), String> {
+    std::fs::create_dir_all(figmog_root)
+        .map_err(|e| format!("creating {}: {e}", figmog_root.display()))?;
+    let path = socket_path(figmog_root);
+
+    if path.exists() {
+        let connect_result = UnixStream::connect(&path).and_then(|stream| {
+            stream.set_read_timeout(Some(SOCKET_PROBE_TIMEOUT))?;
+            Ok(())
+        });
+        match classify_probe(connect_result) {
+            StaleProbe::Owned => {
+                return Err("another figmog serve owns this root".to_string());
+            }
+            StaleProbe::Stale => {
+                std::fs::remove_file(&path)
+                    .map_err(|e| format!("removing stale socket {}: {e}", path.display()))?;
+            }
+        }
+    }
+
+    let listener =
+        UnixListener::bind(&path).map_err(|e| format!("binding socket {}: {e}", path.display()))?;
+    let mut perms = std::fs::metadata(&path)
+        .map_err(|e| e.to_string())?
+        .permissions();
+    perms.set_mode(0o600);
+    std::fs::set_permissions(&path, perms).map_err(|e| e.to_string())?;
+    Ok((listener, path))
+}
+
+/// Unlinks the control-plane socket file on drop. Every one of
+/// `run_serve`'s return points — a clean stdin-EOF exit, a watch-loop
+/// disconnect, a future early error after the socket was bound — drops
+/// this implicitly (it's held in a local binding for the rest of the
+/// function's scope), so "unlinked on clean exit" (spec §1) is structural
+/// rather than a set of hand-maintained cleanup calls at each return site.
+/// Never constructed for a probe that found another serve owning the root:
+/// [`bind_socket`] returns `Err` before creating one in that case, and that
+/// socket file is not this process's to remove.
+struct SocketGuard(PathBuf);
+
+impl Drop for SocketGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+/// Accept loop for the control-plane socket, on its own thread: each
+/// connection gets its own reader thread forwarding newline-delimited
+/// frames into `tx` tagged with a fresh connection id, with its write half
+/// stored in `registry` first (so a request that arrives and is answered
+/// before the *next* line is even read still has somewhere to route its
+/// response). An accept or clone failure for one connection is skipped
+/// rather than tearing down the whole listener — a transient per-connection
+/// hiccup shouldn't take the control plane down.
+fn spawn_socket_acceptor(
+    listener: UnixListener,
+    tx: mpsc::Sender<Incoming>,
+    registry: ConnRegistry,
+) {
+    std::thread::spawn(move || {
+        let next_id = AtomicU64::new(0);
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            let Ok(write_half) = stream.try_clone() else {
+                continue;
+            };
+            let conn_id = next_id.fetch_add(1, Ordering::Relaxed);
+            registry.lock().unwrap().insert(conn_id, write_half);
+
+            let tx = tx.clone();
+            let registry = registry.clone();
+            std::thread::spawn(move || {
+                let reader = BufReader::new(stream);
+                for line in reader.lines() {
+                    match line {
+                        Ok(l) => {
+                            if tx.send(Incoming::Socket(conn_id, l)).is_err() {
+                                break;
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+                // The client disconnected (or sent something unreadable):
+                // drop its write half so a response computed just before
+                // this point (still in flight through `tx`) finds no entry
+                // to write to instead of writing into a dead socket.
+                registry.lock().unwrap().remove(&conn_id);
+            });
+        }
+    });
+}
+
+/// Write one response frame back to `conn_id`'s socket connection, if it's
+/// still registered — a client that vanished mid-request (its reader
+/// thread already removed the entry) simply has nothing to write to,
+/// matching every other "vanished client" path in this file: the response
+/// is dropped, not a panic and not a wedged loop. A write failure (the
+/// connection died between registration and this write) removes the now-
+/// dead entry too, so a later response for the same id doesn't retry a
+/// broken pipe.
+fn write_socket_response(registry: &ConnRegistry, conn_id: u64, resp: &Value) {
+    let mut reg = registry.lock().unwrap();
+    let Some(stream) = reg.get_mut(&conn_id) else {
+        return;
+    };
+    let text = resp.to_string();
+    if writeln!(stream, "{text}").is_err() || stream.flush().is_err() {
+        reg.remove(&conn_id);
+    }
+}
+
 /// How long to wait before the next watch tick, given how many sessions
 /// are being round-robin polled: the full `interval` split evenly across
 /// them (so each file gets, on average, one Tier-3 poll per `interval`),
@@ -92,7 +298,8 @@ fn tick_deadline(interval: Duration, session_count: usize) -> Duration {
     (interval / session_count as u32).max(MIN_TICK_DEADLINE)
 }
 
-/// Run the MCP stdio server. `db_override` is the CLI's legacy `--db
+/// Run the MCP stdio server (plus, unless `no_socket`, the unix-socket
+/// control plane — spec §1). `db_override` is the CLI's legacy `--db
 /// <path>` escape hatch (pre-v4, single-session semantics preserved
 /// exactly — see `cli::dispatch`'s note on this branch); when absent,
 /// `files` (zero or more, `--figmog-root`-rooted) are each mirrored at
@@ -101,6 +308,7 @@ fn tick_deadline(interval: Duration, session_count: usize) -> Duration {
 /// native desktop MCP server at `upstream_url` as a cached proxy (build
 /// design §12); a failed probe degrades to local-only tools with one
 /// stderr line, never a hard error.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn run_serve(
     db_override: Option<PathBuf>,
     files: Vec<String>,
@@ -109,9 +317,48 @@ pub(crate) fn run_serve(
     upstream_url: String,
     no_upstream: bool,
     figmog_root: PathBuf,
+    no_socket: bool,
 ) -> Result<(), String> {
     let interval_dur = clamp_interval(interval);
     let token = std::env::var("FIGMA_TOKEN").ok();
+
+    // Bind the control-plane socket (spec §1) before anything else touches
+    // the filesystem for this run: a stale-probe conflict ("another figmog
+    // serve owns this root") should fail fast and unambiguously, never
+    // masked by an unrelated fjall store-lock panic from a session this
+    // process would otherwise go on to open first. `_socket_guard` is held
+    // for the rest of this function purely for its `Drop` impl (unlinking
+    // the socket file) — every return point below drops it implicitly.
+    let (tx, rx) = mpsc::channel::<Incoming>();
+    let registry: ConnRegistry = Arc::new(Mutex::new(HashMap::new()));
+    let _socket_guard: Option<SocketGuard> = if no_socket {
+        None
+    } else {
+        let (listener, path) = bind_socket(&figmog_root)?;
+        spawn_socket_acceptor(listener, tx.clone(), registry.clone());
+        Some(SocketGuard(path))
+    };
+
+    // Reader thread: stdin lines -> mpsc, tagged `Incoming::Stdio` (see
+    // `Incoming`'s doc comment for why EOF now sends an explicit
+    // `StdinClosed` sentinel rather than relying on every `tx` clone being
+    // dropped).
+    {
+        let tx = tx.clone();
+        std::thread::spawn(move || {
+            for line in std::io::stdin().lock().lines() {
+                match line {
+                    Ok(l) => {
+                        if tx.send(Incoming::Stdio(l)).is_err() {
+                            return;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            let _ = tx.send(Incoming::StdinClosed);
+        });
+    }
 
     let (mut manager, track_current) = build_sessions(
         db_override,
@@ -155,51 +402,38 @@ pub(crate) fn run_serve(
     }
 
     eprintln!(
-        "{} serving {} file(s) (watch {}, upstream {upstream_status})",
+        "{} serving {} file(s) (watch {}, upstream {upstream_status}, socket {})",
         mcp::SERVER_NAME,
         manager.sessions.len(),
-        if no_watch { "off" } else { "on" }
+        if no_watch { "off" } else { "on" },
+        if no_socket { "off" } else { "on" }
     );
-
-    // Reader thread: stdin lines -> mpsc. EOF (or any read error) drops
-    // `tx`, which is how the main loop learns to exit (`recv`/`recv_timeout`
-    // return `Disconnected`).
-    let (tx, rx) = mpsc::channel::<String>();
-    std::thread::spawn(move || {
-        for line in std::io::stdin().lock().lines() {
-            match line {
-                Ok(l) => {
-                    if tx.send(l).is_err() {
-                        break;
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-    });
 
     let mut next_session_idx: usize = 0;
     let mut next_deadline = Instant::now() + tick_deadline(interval_dur, manager.sessions.len());
 
     loop {
         let incoming = if no_watch {
-            // No ticking to do, so a disconnect (stdin EOF) is the only
-            // thing `recv` can report besides a line — exit clean rather
-            // than falling into the (watch-only) timeout branch below.
+            // No ticking to do, so a disconnect (all senders dropped — in
+            // practice unreachable once the socket is on, since the
+            // acceptor thread holds its own `tx` clone forever, but still
+            // handled) is the only other thing `recv` can report besides a
+            // message — exit clean rather than falling into the
+            // (watch-only) timeout branch below.
             match rx.recv() {
-                Ok(line) => Some(line),
+                Ok(msg) => Some(msg),
                 Err(mpsc::RecvError) => return Ok(()),
             }
         } else {
             let wait = next_deadline.saturating_duration_since(Instant::now());
             match rx.recv_timeout(wait) {
-                Ok(line) => Some(line),
+                Ok(msg) => Some(msg),
                 Err(mpsc::RecvTimeoutError::Timeout) => None,
                 Err(mpsc::RecvTimeoutError::Disconnected) => return Ok(()),
             }
         };
 
-        let Some(line) = incoming else {
+        let Some(msg) = incoming else {
             // Timeout with watch enabled: round-robin one session's meta
             // poll, pulling inline on change (spec §14).
             next_deadline = watch_tick(
@@ -209,6 +443,31 @@ pub(crate) fn run_serve(
                 track_current,
             );
             continue;
+        };
+
+        let line = match msg {
+            Incoming::StdinClosed => return Ok(()),
+            Incoming::Stdio(l) => l,
+            Incoming::Socket(conn_id, l) => {
+                let mut handler =
+                    FnHandler(|name: &str, args: &Value| -> Result<ToolOutput, String> {
+                        handle_tool_call(
+                            &mut manager,
+                            &mut upstream,
+                            upstream_status,
+                            no_watch,
+                            track_current,
+                            interval_dur,
+                            &mut next_deadline,
+                            name,
+                            args,
+                        )
+                    });
+                if let Some(resp) = mcp::handle_message(&l, &tools, &mut handler) {
+                    write_socket_response(&registry, conn_id, &resp);
+                }
+                continue;
+            }
         };
 
         let mut handler = FnHandler(|name: &str, args: &Value| -> Result<ToolOutput, String> {
@@ -669,5 +928,127 @@ mod tests {
             tick_deadline(Duration::from_secs(10), 100),
             Duration::from_secs(2)
         );
+    }
+
+    // ---- unix-socket control plane (v0.0.2 spec §1) ----
+
+    #[test]
+    fn classify_probe_connect_success_means_owned() {
+        assert_eq!(classify_probe(Ok(())), StaleProbe::Owned);
+    }
+
+    #[test]
+    fn classify_probe_connection_refused_means_stale() {
+        let err = std::io::Error::from(std::io::ErrorKind::ConnectionRefused);
+        assert_eq!(classify_probe(Err(err)), StaleProbe::Stale);
+    }
+
+    #[test]
+    fn classify_probe_any_other_connect_error_also_means_stale() {
+        // A path that exists but isn't a live listening socket at all
+        // (garbage, or some other filesystem error) is treated the same
+        // as a refused connection — see `classify_probe`'s doc comment.
+        let err = std::io::Error::other("not a socket");
+        assert_eq!(classify_probe(Err(err)), StaleProbe::Stale);
+    }
+
+    #[test]
+    fn incoming_messages_carry_their_connection_tag_through_the_channel() {
+        // Proves the tagging/routing mechanism itself: several sources
+        // (stdin, two different socket connections) share one channel, and
+        // each `Incoming` value on the receiving end still carries enough
+        // information to route a response back to the right place.
+        let (tx, rx) = mpsc::channel::<Incoming>();
+        tx.send(Incoming::Stdio("stdio line".to_string())).unwrap();
+        tx.send(Incoming::Socket(7, "first conn".to_string()))
+            .unwrap();
+        tx.send(Incoming::Socket(9, "second conn".to_string()))
+            .unwrap();
+        tx.send(Incoming::StdinClosed).unwrap();
+
+        match rx.recv().unwrap() {
+            Incoming::Stdio(l) => assert_eq!(l, "stdio line"),
+            other => panic!("expected Stdio, got {other:?}"),
+        }
+        match rx.recv().unwrap() {
+            Incoming::Socket(id, l) => {
+                assert_eq!(id, 7);
+                assert_eq!(l, "first conn");
+            }
+            other => panic!("expected Socket(7, ..), got {other:?}"),
+        }
+        match rx.recv().unwrap() {
+            Incoming::Socket(id, l) => {
+                assert_eq!(id, 9);
+                assert_eq!(l, "second conn");
+            }
+            other => panic!("expected Socket(9, ..), got {other:?}"),
+        }
+        assert!(matches!(rx.recv().unwrap(), Incoming::StdinClosed));
+    }
+
+    #[test]
+    fn write_socket_response_delivers_to_the_registered_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let client = UnixStream::connect(&path).unwrap();
+        let (server_side, _) = listener.accept().unwrap();
+
+        let registry: ConnRegistry = Arc::new(Mutex::new(HashMap::new()));
+        registry.lock().unwrap().insert(1, server_side);
+
+        write_socket_response(&registry, 1, &json!({"hello": "world"}));
+
+        let mut reader = BufReader::new(client);
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        let v: Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(v, json!({"hello": "world"}));
+        // The write succeeded, so the entry is still there for a
+        // subsequent response on the same connection.
+        assert!(registry.lock().unwrap().contains_key(&1));
+    }
+
+    #[test]
+    fn write_socket_response_for_an_unregistered_connection_is_a_silent_no_op() {
+        // A response for a connection id that was never registered (or
+        // whose entry was already removed — the client vanished) must not
+        // panic; the response is simply dropped.
+        let registry: ConnRegistry = Arc::new(Mutex::new(HashMap::new()));
+        write_socket_response(&registry, 999, &json!({"ignored": true}));
+        assert!(registry.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn bind_socket_creates_a_0600_file_and_a_second_probe_sees_it_as_owned() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        let (listener, path) = bind_socket(&root).expect("first bind should succeed");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "socket file should be mode 0600");
+
+        // A second bind attempt against the same root, with the first
+        // listener still alive, must classify the existing file as owned
+        // (spec §1: "success ⇒ another serve owns this root") rather than
+        // stealing it.
+        let err = bind_socket(&root).unwrap_err();
+        assert!(err.contains("another figmog serve owns this root"), "{err}");
+
+        drop(listener);
+    }
+
+    #[test]
+    fn bind_socket_unlinks_and_rebinds_a_stale_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        std::fs::create_dir_all(&root).unwrap();
+        // A leftover regular file at the socket path, with nothing
+        // listening — the simplest reproduction of a stale socket from an
+        // unclean exit.
+        std::fs::write(socket_path(&root), b"not a socket").unwrap();
+
+        let (listener, _path) = bind_socket(&root).expect("stale file should be reclaimed");
+        drop(listener);
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -521,8 +521,17 @@ fn handle_tool_call(
             // failed call (almost always "no node ... in the mirror" —
             // the node genuinely isn't in the file the explicit arg
             // picked) rather than staying silent about why a URL that
-            // looks right didn't resolve.
-            match (&explicit_file, &url_file_key) {
+            // looks right didn't resolve. `explicit_file` is compared by
+            // its *normalized* key, not its raw text — it can itself be a
+            // full Figma URL (or a bare key) naming the very same file
+            // `url_file_key` already extracted, and a raw-string compare
+            // would false-positive on that (same file, different spelling).
+            // A `file` arg `parse_file_ref` can't make sense of at all
+            // falls back to the raw text so a genuine mismatch still shows.
+            let explicit_key = explicit_file
+                .as_deref()
+                .map(|f| parse_file_ref(f).unwrap_or_else(|| f.to_string()));
+            match (&explicit_key, &url_file_key) {
                 (Some(ef), Some(uf)) if ef != uf => {
                     format!(
                         "{msg} (note: the id/under URL names file {uf}, but the explicit `file` argument {ef} was used instead)"

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -234,6 +234,18 @@ fn bind_socket(figmog_root: &Path) -> Result<(UnixListener, PathBuf), String> {
 /// return site. Never constructed for a probe that found another serve
 /// owning the root: [`bind_socket`] returns `Err` before creating one in
 /// that case, and that socket file is not this process's to remove.
+///
+/// Best-effort, not a hard guarantee: on filesystems that recycle inode
+/// numbers aggressively (ext4, notably — see the two-live-files-then-
+/// `rename(2)` construction the `socket_guard_does_not_unlink_a_file_
+/// replaced_at_the_same_path` test needs to reliably prove the *positive*
+/// case on Linux), an unlink immediately followed by an unrelated create at
+/// the exact same path could in principle land on the same `(dev, ino)`
+/// this guard bound, purely by chance — no attacker or racer required.
+/// This is an accepted, narrow gap in an already best-effort safety net
+/// (spec §1 has no auth story for the socket beyond filesystem
+/// permissions to begin with), not a design this crate tries to close
+/// further.
 struct SocketGuard {
     path: PathBuf,
     dev: u64,
@@ -1231,14 +1243,29 @@ mod tests {
         // recreating the socket path while serve is still running (m3):
         // the guard must check the file is still the *inode* it bound, not
         // just that "something" exists at the path, before removing it.
+        //
+        // The replacement is built at a *sibling* path while the original
+        // still exists, then moved over the guard's path with `rename(2)`
+        // — the only way to guarantee a genuinely different inode across
+        // platforms. A plain remove-then-recreate at the same path doesn't
+        // reliably do that: ext4 (the common Linux CI filesystem) recycles
+        // inode numbers immediately, so a delete-then-recreate at the same
+        // path can legitimately land on the exact same inode the guard
+        // bound — which would make this test pass for the wrong reason on
+        // Linux (or, as originally written, fail there outright, since two
+        // *simultaneously live* files are guaranteed distinct inodes but a
+        // remove-then-recreate isn't). `rename(2)` preserves the source
+        // inode across the move, so the file at `path` afterward is
+        // provably not the guard's original inode, on every platform.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("root");
         let (listener, path) = bind_socket(&root).unwrap();
         let guard = SocketGuard::new(path.clone()).unwrap();
         drop(listener);
 
-        std::fs::remove_file(&path).unwrap();
-        std::fs::write(&path, b"someone else's file now").unwrap();
+        let replacement = dir.path().join("replacement");
+        std::fs::write(&replacement, b"someone else's file now").unwrap();
+        std::fs::rename(&replacement, &path).unwrap();
 
         drop(guard);
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -691,7 +691,9 @@ fn build_sessions(
         if !no_watch {
             let session = &mut manager.sessions[0];
             if !session.mirrored {
-                sessions::do_pull(session, interval).map_err(|(message, _wait)| message)?;
+                // No user-facing geometry flag at startup (spec §4) — the
+                // mirror's stored setting, if any, still drives this.
+                sessions::do_pull(session, interval, false).map_err(|(message, _wait)| message)?;
             }
         }
         // `--db` never resolves a tracked key (pre-v4: `resolve_db`
@@ -722,7 +724,9 @@ fn build_sessions(
         let session = manager.open(f)?;
         let key = session.key.clone();
         let just_pulled = if !no_watch && !session.mirrored {
-            sessions::do_pull(session, interval).map_err(|(message, _wait)| message)?;
+            // No user-facing geometry flag at startup (spec §4) — the
+            // mirror's stored setting, if any, still drives this.
+            sessions::do_pull(session, interval, false).map_err(|(message, _wait)| message)?;
             true
         } else {
             false
@@ -776,7 +780,10 @@ fn watch_tick(
     match session.watcher.tick(&api, &key) {
         Tick::Unchanged => Instant::now() + deadline,
         Tick::Wait { after } => Instant::now() + after,
-        Tick::Changed => match sessions::do_pull(session, interval) {
+        // A background watch tick carries no user-facing geometry flag
+        // (spec §4) — the mirror's stored setting, if any, still drives
+        // this.
+        Tick::Changed => match sessions::do_pull(session, interval, false) {
             Ok(_outcome) => {
                 refresh_current(manager, track_current, &key);
                 Instant::now() + deadline
@@ -829,8 +836,14 @@ fn handle_tool_call(
 
     if name == "figmog_open" {
         let file = dispatch::require_str(args, "file")?;
+        // spec §4: `geometry` turns sticky vector-geometry requests on for
+        // this mirror going forward; omitted preserves whatever's already
+        // stored (default false for a brand-new mirror) — `do_pull`'s
+        // stored-flag union handles that, so `false` here is exactly "no
+        // new override" rather than "force off".
+        let geometry = dispatch::arg_bool(args, "geometry");
         let session = manager.open(&file)?;
-        let outcome = match sessions::do_pull(session, interval) {
+        let outcome = match sessions::do_pull(session, interval, geometry) {
             Ok(outcome) => outcome,
             Err((message, wait)) => {
                 *next_deadline = Instant::now() + wait;
@@ -891,7 +904,10 @@ fn handle_tool_call(
             // `figmog_sync` would otherwise always perform.
             let outcome = match just_pulled {
                 Some(outcome) => outcome,
-                None => match sessions::do_pull(session, interval) {
+                // `figmog_sync` carries no geometry arg of its own (spec
+                // §4) — the mirror's stored setting, if any, still drives
+                // this re-pull.
+                None => match sessions::do_pull(session, interval, false) {
                     Ok(outcome) => outcome,
                     Err((message, wait)) => {
                         *next_deadline = Instant::now() + wait;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -33,7 +33,7 @@
 //!
 //! **v3 (build design §12):** unless `--no-upstream`, figmog also probes
 //! Figma's native desktop MCP server at startup and becomes the *only*
-//! Figma MCP an agent needs — `tools/list` merges the 19 local `figmog_*`
+//! Figma MCP an agent needs — `tools/list` merges the 20 local `figmog_*`
 //! tools with every upstream tool verbatim (`proxy::merge_registry`), and
 //! `tools/call` routes by the namespace rule (`proxy::is_local_tool`).
 //! Upstream routing is global, not per-session: the desktop server serves
@@ -470,7 +470,16 @@ fn handle_tool_call(
         })));
     }
 
-    let file_arg = args.get("file").and_then(Value::as_str).map(str::to_string);
+    // spec §2b: an explicit `file` arg always wins, but when it's absent
+    // and the call's node-id-shaped argument (`id`/`under`/`target`) is a
+    // full Figma URL naming a file, that URL's file key routes the call
+    // (auto-open semantics apply, same as an explicit `file`). When both
+    // are present and disagree, the explicit arg still wins — the
+    // disagreement is only surfaced as a note on a not-found error below,
+    // never silently overridden the other way.
+    let explicit_file = args.get("file").and_then(Value::as_str).map(str::to_string);
+    let url_file_key = dispatch::infer_file_from_node_ref(args);
+    let file_arg = explicit_file.clone().or_else(|| url_file_key.clone());
     let mut call_args = args.clone();
     if let Some(obj) = call_args.as_object_mut() {
         obj.remove("file");
@@ -507,7 +516,21 @@ fn handle_tool_call(
             return Ok(ToolOutput::Json(churn_value));
         }
 
-        let result = (session.dispatch)(name, &call_args)?;
+        let result = (session.dispatch)(name, &call_args).map_err(|msg| {
+            // spec §2b: note an explicit-file/URL-file disagreement on a
+            // failed call (almost always "no node ... in the mirror" —
+            // the node genuinely isn't in the file the explicit arg
+            // picked) rather than staying silent about why a URL that
+            // looks right didn't resolve.
+            match (&explicit_file, &url_file_key) {
+                (Some(ef), Some(uf)) if ef != uf => {
+                    format!(
+                        "{msg} (note: the id/under URL names file {uf}, but the explicit `file` argument {ef} was used instead)"
+                    )
+                }
+                _ => msg,
+            }
+        })?;
         if name == "figmog_status"
             && let ToolOutput::Json(mut v) = result
         {
@@ -564,10 +587,10 @@ mod tests {
         })]);
         let (tools, dropped) = proxy::merge_registry(local_registry(), upstream.tools());
         assert!(dropped.is_empty());
-        assert_eq!(tools.len(), 20);
-        assert!(tools[..19].iter().all(|t| t.name.starts_with("figmog_")));
-        assert_eq!(tools[19].name, "get_design_context");
-        assert!(tools[19].description.starts_with("[via Figma desktop] "));
+        assert_eq!(tools.len(), 21);
+        assert!(tools[..20].iter().all(|t| t.name.starts_with("figmog_")));
+        assert_eq!(tools[20].name, "get_design_context");
+        assert!(tools[20].description.starts_with("[via Figma desktop] "));
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -64,7 +64,12 @@ pub(crate) struct PullOutcome {
 // can't be named (this module's doc comment), so it can never appear in a
 // named struct field directly — only behind one of these closures.
 type DispatchFn = Box<dyn FnMut(&str, &Value) -> Result<ToolOutput, String>>;
-type PullFn = Box<dyn FnMut() -> Result<PullOutcome, PullError>>;
+/// `bool` argument: this pull's own geometry override (spec §4) —
+/// `figmog_open`'s `geometry` arg, or `false` from every other call site
+/// (startup, watch tick, `figmog_sync`, auto-open), which don't carry a
+/// user-facing override of their own and so just let the mirror's already-
+/// stored setting (if any) keep driving the request — see [`do_pull`].
+type PullFn = Box<dyn FnMut(bool) -> Result<PullOutcome, PullError>>;
 type WatermarkFn = Box<dyn FnMut() -> Option<String>>;
 type ProxyCacheFn = Box<
     dyn FnMut(&mut crate::upstream::HttpUpstream, &str, &Value) -> Result<(Value, bool), String>,
@@ -140,8 +145,9 @@ impl FileSession {
 pub(crate) fn do_pull(
     session: &mut FileSession,
     interval: Duration,
+    geometry: bool,
 ) -> Result<PullOutcome, (String, Duration)> {
-    match (session.pull)() {
+    match (session.pull)(geometry) {
         Ok(outcome) => {
             session.note_pull_success(&outcome);
             Ok(outcome)
@@ -207,15 +213,25 @@ pub(crate) fn open_session_at(
         let st = st.clone();
         let network_key = network_key.clone();
         let token = token.clone();
-        move || -> Result<PullOutcome, PullError> {
+        move |geometry_override: bool| -> Result<PullOutcome, PullError> {
             let key = network_key.clone().ok_or_else(|| {
                 PullError::from("no file key: pass a file key or figma.com URL".to_string())
             })?;
             let token = token.clone().ok_or_else(|| {
                 PullError::from("FIGMA_TOKEN not set — required for network pulls".to_string())
             })?;
+            // Sticky vector geometry (spec §4): what this pull requests
+            // combines its own override (`figmog_open`'s `geometry` arg,
+            // or `false` from every other caller — see `PullFn`'s doc
+            // comment) with whatever's already stored, so a plain re-pull
+            // of a mirror that was ever opened with `--geometry`/
+            // `geometry: true` keeps asking for it.
+            let stored_geometry = st
+                .borrow()
+                .rtx(|(.., mirror_config)| store::read_geometry(&mirror_config));
+            let request_geometry = store::effective_geometry(geometry_override, stored_geometry);
             let api = UreqApi::new(token);
-            let resp = api.file(&key)?;
+            let resp = api.file(&key, request_geometry)?;
             // Opportunistic Enterprise variables sync (spec §12): `Ok(None)`
             // on non-Enterprise plans is not an error — v1 behavior
             // (import/inference, sweep-exempt) holds unchanged below.
@@ -231,7 +247,7 @@ pub(crate) fn open_session_at(
                 let var_recs = crate::vars::parse_variables_export(v).map_err(|e| e.to_string())?;
                 flattened.recs.extend(var_recs);
                 let stored_var_ids =
-                    st.rtx(|(_, _, _, _, variables, variable_collections, _, _)| {
+                    st.rtx(|(_, _, _, _, variables, variable_collections, _, _, _)| {
                         collect_variable_ids(&variables, &variable_collections)
                     });
                 prior.extend(stored_var_ids);
@@ -245,10 +261,15 @@ pub(crate) fn open_session_at(
             // actually move, with no separate "did it change" check needed.
             let version = flattened.file.version.clone();
             let stale =
-                st.rtx(|(_, _, _, _, _, _, _, cache)| store::stale_cache_ids(&cache, &version));
+                st.rtx(|(_, _, _, _, _, _, _, cache, _)| store::stale_cache_ids(&cache, &version));
             if !stale.is_empty() {
                 store::evict_stale_cache(&mut st, &stale);
             }
+
+            // Persist the (possibly just-turned-on) geometry flag so the
+            // *next* pull's own peek above sees it, even if this call's
+            // override was the only reason it was requested this time.
+            store::upsert_mirror_config(&mut st, request_geometry);
 
             Ok(PullOutcome {
                 churn,
@@ -259,19 +280,19 @@ pub(crate) fn open_session_at(
     };
 
     if pull_now {
-        pull_closure().map_err(|e| e.to_string())?;
+        pull_closure(false).map_err(|e| e.to_string())?;
     }
 
     let meta_present = st
         .borrow()
-        .rtx(|(_, _, _, _, _, _, meta, _)| meta.get(&0).is_some());
+        .rtx(|(_, _, _, _, _, _, meta, _, _)| meta.get(&0).is_some());
     let name = st
         .borrow()
-        .rtx(|(_, _, _, _, _, _, meta, _)| meta.get(&0).map(|m| m.name.clone()))
+        .rtx(|(_, _, _, _, _, _, meta, _, _)| meta.get(&0).map(|m| m.name.clone()))
         .unwrap_or_else(|| key.clone());
     let seen = st
         .borrow()
-        .rtx(|(_, _, _, _, _, _, meta, _)| meta.get(&0).map(|m| m.last_modified.clone()));
+        .rtx(|(_, _, _, _, _, _, meta, _, _)| meta.get(&0).map(|m| m.last_modified.clone()));
 
     let dispatch: DispatchFn = {
         let st = st.clone();
@@ -297,7 +318,7 @@ pub(crate) fn open_session_at(
         let st = st.clone();
         Box::new(move || {
             st.borrow()
-                .rtx(|(_, _, _, _, _, _, meta, _)| meta.get(&0).map(|m| m.last_modified.clone()))
+                .rtx(|(_, _, _, _, _, _, meta, _, _)| meta.get(&0).map(|m| m.last_modified.clone()))
         })
     };
 
@@ -306,7 +327,7 @@ pub(crate) fn open_session_at(
         Box::new(move |upstream, name, args| {
             let args_canonical = crate::proxy::canonical_args(args)?;
             let version_and_hit = if crate::proxy::is_cacheable(name, args) {
-                st.borrow().rtx(|(_, _, _, _, _, _, meta, cache)| {
+                st.borrow().rtx(|(_, _, _, _, _, _, meta, cache, _)| {
                     let version = meta.get(&0).map(|m| m.version.clone());
                     let hit = version
                         .as_ref()
@@ -424,7 +445,11 @@ impl SessionManager {
                 if session.mirrored {
                     Ok((session, None))
                 } else {
-                    match do_pull(session, interval) {
+                    // No user-facing geometry override reaches an implicit
+                    // auto-open (only `figmog_open` carries one) — this
+                    // just lets the mirror's stored setting, if any, drive
+                    // the request (spec §4).
+                    match do_pull(session, interval, false) {
                         Ok(outcome) => Ok((session, Some(outcome))),
                         Err((message, wait)) => Err(ResolveError {
                             message,
@@ -515,7 +540,7 @@ mod tests {
         let watermark: WatermarkFn = Box::new(|| Some("t".to_string()));
         let pull: PullFn = {
             let pull_calls = pull_calls.clone();
-            Box::new(move || {
+            Box::new(move |_geometry: bool| {
                 let call_index = *pull_calls.borrow();
                 *pull_calls.borrow_mut() += 1;
                 script(call_index)
@@ -782,7 +807,7 @@ mod tests {
             });
         session.backoff = backoff;
 
-        let (message, wait) = do_pull(&mut session, Duration::from_secs(10)).unwrap_err();
+        let (message, wait) = do_pull(&mut session, Duration::from_secs(10), false).unwrap_err();
         assert!(message.contains("retry after"), "{message}");
         // `pull_failure_wait` honors Retry-After for a rate limit
         // regardless of the configured interval, and does NOT touch the
@@ -791,5 +816,52 @@ mod tests {
         assert_eq!(wait, Duration::from_secs(90));
         assert_eq!(session.backoff, BACKOFF_START);
         let _ = &mut backoff;
+    }
+
+    // ---- sticky vector geometry (v0.0.2 spec §4) ----
+
+    /// [`do_pull`]'s `geometry` argument must reach the session's own
+    /// `pull` closure unchanged — the plumbing every re-pull call site
+    /// (`figmog_open`'s explicit arg, or `false` from every other caller:
+    /// startup, watch tick, `figmog_sync`, auto-open) relies on. The
+    /// closure's own decision to union this with the stored flag
+    /// (`store::effective_geometry`) is proven separately and purely at
+    /// the store/api layer — this test only proves the *argument*
+    /// threading, at the one layer (`FileSession`/`SessionManager`) that
+    /// can't be exercised without a real store or network.
+    #[test]
+    fn do_pull_forwards_its_geometry_argument_to_the_session_pull_closure() {
+        let seen: Rc<RefCell<Vec<bool>>> = Rc::new(RefCell::new(Vec::new()));
+        let pull: PullFn = {
+            let seen = seen.clone();
+            Box::new(move |geometry: bool| {
+                seen.borrow_mut().push(geometry);
+                Ok(PullOutcome {
+                    churn: Churn::default(),
+                    name: "Scripted".to_string(),
+                    version: "1".to_string(),
+                })
+            })
+        };
+        let mut session = FileSession {
+            key: "keyA1234567890".to_string(),
+            name: "Scripted".to_string(),
+            dispatch: Box::new(|_name, _args| Ok(ToolOutput::Json(json!({})))),
+            pull,
+            watermark: Box::new(|| Some("t".to_string())),
+            proxy_cache: Box::new(|_upstream, name, _args| {
+                Err(format!(
+                    "scripted session has no store to proxy through: {name}"
+                ))
+            }),
+            watcher: Watcher::new(None),
+            backoff: BACKOFF_START,
+            mirrored: false,
+        };
+
+        do_pull(&mut session, Duration::from_secs(10), true).unwrap();
+        do_pull(&mut session, Duration::from_secs(10), false).unwrap();
+
+        assert_eq!(*seen.borrow(), vec![true, false]);
     }
 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -74,6 +74,15 @@ type WatermarkFn = Box<dyn FnMut() -> Option<String>>;
 type ProxyCacheFn = Box<
     dyn FnMut(&mut crate::upstream::HttpUpstream, &str, &Value) -> Result<(Value, bool), String>,
 >;
+/// `figmog_images` (v0.0.2 spec §5): `(ids, format, scale) ->` every
+/// requested render/fill, cache-first. A fifth closure beyond `dispatch`/
+/// `pull`/`watermark`/`proxy_cache`, for the same structural reason as
+/// `proxy_cache` — it needs this session's own store (for caching) *and*
+/// the network (for misses), so it can't be answered by `dispatch`
+/// (read-only) or folded into `pull` (a different fetch/cache shape
+/// entirely, and images is never automatic — see this type's own callers).
+type ImagesFn =
+    Box<dyn FnMut(&[String], &str, Option<f64>) -> Result<Vec<crate::images::ImageItem>, String>>;
 
 /// One mirrored Figma file. `dispatch` answers the 16 read-only
 /// `figmog_*` tools (everything [`dispatch::dispatch_read_tool`] knows);
@@ -103,6 +112,9 @@ type ProxyCacheFn = Box<
 /// from behind one of these closures. `serve.rs` calls it only for the
 /// *default* session — see its own doc comment for why proxied calls
 /// route through the default rather than any per-call `file` argument.
+///
+/// `images` (v0.0.2 spec §5) is a fifth — see [`ImagesFn`]'s own doc
+/// comment.
 pub(crate) struct FileSession {
     pub(crate) key: String,
     pub(crate) name: String,
@@ -110,6 +122,7 @@ pub(crate) struct FileSession {
     pub(crate) pull: PullFn,
     pub(crate) watermark: WatermarkFn,
     pub(crate) proxy_cache: ProxyCacheFn,
+    pub(crate) images: ImagesFn,
     pub(crate) watcher: Watcher,
     pub(crate) backoff: Duration,
     pub(crate) mirrored: bool,
@@ -228,7 +241,7 @@ pub(crate) fn open_session_at(
             // `geometry: true` keeps asking for it.
             let stored_geometry = st
                 .borrow()
-                .rtx(|(.., mirror_config)| store::read_geometry(&mirror_config));
+                .rtx(|(.., mirror_config, _)| store::read_geometry(&mirror_config));
             let request_geometry = store::effective_geometry(geometry_override, stored_geometry);
             let api = UreqApi::new(token);
             let resp = api.file(&key, request_geometry)?;
@@ -246,23 +259,29 @@ pub(crate) fn open_session_at(
             if let Some(v) = &vars_resp {
                 let var_recs = crate::vars::parse_variables_export(v).map_err(|e| e.to_string())?;
                 flattened.recs.extend(var_recs);
-                let stored_var_ids =
-                    st.rtx(|(_, _, _, _, variables, variable_collections, _, _, _)| {
+                let stored_var_ids = st.rtx(
+                    |(_, _, _, _, variables, variable_collections, _, _, _, _)| {
                         collect_variable_ids(&variables, &variable_collections)
-                    });
+                    },
+                );
                 prior.extend(stored_var_ids);
             }
             let churn = store::sync(&mut st, &prior, &flattened, now_ms());
 
             // Cache eviction lives here rather than folded into `sync`
             // (store.rs's own note): a version-changing pull sweeps stale
-            // `proxy_cache` rows; computing `stale` against the version
-            // just synced makes this a no-op whenever the version didn't
+            // `proxy_cache` rows (and, v0.0.2 spec §5, stale `images` rows
+            // the same way); computing `stale` against the version just
+            // synced makes this a no-op whenever the version didn't
             // actually move, with no separate "did it change" check needed.
             let version = flattened.file.version.clone();
-            let stale =
-                st.rtx(|(_, _, _, _, _, _, _, cache, _)| store::stale_cache_ids(&cache, &version));
+            let mut stale = st.rtx(|(_, _, _, _, _, _, _, cache, _, images)| {
+                let mut stale = store::stale_cache_ids(&cache, &version);
+                stale.extend(store::stale_image_ids(&images, &version));
+                stale
+            });
             if !stale.is_empty() {
+                stale.sort();
                 store::evict_stale_cache(&mut st, &stale);
             }
 
@@ -285,14 +304,14 @@ pub(crate) fn open_session_at(
 
     let meta_present = st
         .borrow()
-        .rtx(|(_, _, _, _, _, _, meta, _, _)| meta.get(&0).is_some());
+        .rtx(|(_, _, _, _, _, _, meta, _, _, _)| meta.get(&0).is_some());
     let name = st
         .borrow()
-        .rtx(|(_, _, _, _, _, _, meta, _, _)| meta.get(&0).map(|m| m.name.clone()))
+        .rtx(|(_, _, _, _, _, _, meta, _, _, _)| meta.get(&0).map(|m| m.name.clone()))
         .unwrap_or_else(|| key.clone());
     let seen = st
         .borrow()
-        .rtx(|(_, _, _, _, _, _, meta, _, _)| meta.get(&0).map(|m| m.last_modified.clone()));
+        .rtx(|(_, _, _, _, _, _, meta, _, _, _)| meta.get(&0).map(|m| m.last_modified.clone()));
 
     let dispatch: DispatchFn = {
         let st = st.clone();
@@ -317,8 +336,9 @@ pub(crate) fn open_session_at(
     let watermark: WatermarkFn = {
         let st = st.clone();
         Box::new(move || {
-            st.borrow()
-                .rtx(|(_, _, _, _, _, _, meta, _, _)| meta.get(&0).map(|m| m.last_modified.clone()))
+            st.borrow().rtx(|(_, _, _, _, _, _, meta, _, _, _)| {
+                meta.get(&0).map(|m| m.last_modified.clone())
+            })
         })
     };
 
@@ -327,7 +347,7 @@ pub(crate) fn open_session_at(
         Box::new(move |upstream, name, args| {
             let args_canonical = crate::proxy::canonical_args(args)?;
             let version_and_hit = if crate::proxy::is_cacheable(name, args) {
-                st.borrow().rtx(|(_, _, _, _, _, _, meta, cache, _)| {
+                st.borrow().rtx(|(_, _, _, _, _, _, meta, cache, _, _)| {
                     let version = meta.get(&0).map(|m| m.version.clone());
                     let hit = version
                         .as_ref()
@@ -342,6 +362,42 @@ pub(crate) fn open_session_at(
         })
     };
 
+    // `figmog_images` (v0.0.2 spec §5): the two-step `scan` (read-only,
+    // this session's own concrete `open_store!` handle — see
+    // `images.rs`'s own doc comment for why that split exists at all) then
+    // `resolve` (network + cache-write) dance, with the session's api
+    // token and network key exactly like `pull_closure` above. `api: None`
+    // when no token was configured at all — `resolve` itself still serves
+    // every cache hit for free in that case (see its own doc comment).
+    let images: ImagesFn = {
+        let st = st.clone();
+        let network_key = network_key.clone();
+        let token = token.clone();
+        Box::new(move |ids: &[String], format: &str, scale: Option<f64>| {
+            let key = network_key
+                .clone()
+                .ok_or_else(|| "no file key: pass a file key or figma.com URL".to_string())?;
+            let node_ids = crate::images::normalize_ids(ids);
+            let scale_m = crate::images::scale_milli(scale);
+            let mut st = st.borrow_mut();
+            let scanned = st.rtx(|((nodes, ..), _, _, _, _, _, meta, _, _, images)| {
+                crate::images::scan(&nodes, &meta, &images, &node_ids, format, scale_m)
+            });
+            let api = token.clone().map(UreqApi::new);
+            let download = crate::api::download_bytes;
+            Ok(crate::images::resolve(
+                &mut st,
+                scanned,
+                api.as_ref().map(|a| a as &dyn crate::api::FigmaApi),
+                &download,
+                &key,
+                &node_ids,
+                format,
+                scale,
+            ))
+        })
+    };
+
     Ok(FileSession {
         key,
         name,
@@ -349,6 +405,7 @@ pub(crate) fn open_session_at(
         pull,
         watermark,
         proxy_cache,
+        images,
         watcher: Watcher::new(seen),
         backoff: BACKOFF_START,
         mirrored: meta_present,
@@ -556,6 +613,9 @@ mod tests {
                 Err(format!(
                     "scripted session has no store to proxy through: {name}"
                 ))
+            }),
+            images: Box::new(|_ids, _format, _scale| {
+                Err("scripted session has no store for images".to_string())
             }),
             watcher: Watcher::new(None),
             backoff: BACKOFF_START,
@@ -853,6 +913,9 @@ mod tests {
                 Err(format!(
                     "scripted session has no store to proxy through: {name}"
                 ))
+            }),
+            images: Box::new(|_ids, _format, _scale| {
+                Err("scripted session has no store for images".to_string())
             }),
             watcher: Watcher::new(None),
             backoff: BACKOFF_START,

--- a/src/store.rs
+++ b/src/store.rs
@@ -11,7 +11,7 @@ use fold::stream::KeyedStream;
 use serde::Serialize;
 
 use crate::flatten::Flattened;
-use crate::model::{FileMeta, Id, MirrorConfigRec, NodeRec, ProxyCacheRec, Rec};
+use crate::model::{FileMeta, Id, ImageBlobRec, MirrorConfigRec, NodeRec, ProxyCacheRec, Rec};
 
 // ---- pipeline branch functions (pure; fold requires determinism) ----
 
@@ -141,6 +141,15 @@ pub fn mirror_config_only(d: &Keyed<Id, Rec>) -> Option<Keyed<u8, MirrorConfigRe
     }
 }
 
+/// Feeds the `images` table: keep only `Rec::ImageBlob` records, keyed by
+/// their own hash (v0.0.2 spec §5) — same pattern as [`proxy_cache_only`].
+pub fn image_only(d: &Keyed<Id, Rec>) -> Option<Keyed<String, ImageBlobRec>> {
+    match (&d.key, &d.val) {
+        (Id::ImageBlob(k), Rec::ImageBlob(r)) => Some(Keyed::new(k.clone(), r.clone())),
+        _ => None,
+    }
+}
+
 /// The full figmog pipeline. Sink names are frozen on-disk schema.
 #[macro_export]
 macro_rules! figmog_pipeline {
@@ -200,6 +209,7 @@ macro_rules! figmog_pipeline {
                 $crate::store::mirror_config_only,
                 terminal::Table::new("mirror_config"),
             ),
+            FilterMap::new($crate::store::image_only, terminal::Table::new("images")),
         )
     }};
 }
@@ -339,13 +349,31 @@ pub fn stale_cache_ids<R: fold::stream::Readable>(
         .collect()
 }
 
-/// Remove `stale` cache rows in one write transaction. Never touches
-/// variables, collections, or the meta row — pass only ids gathered by
-/// [`stale_cache_ids`].
+/// `ImageBlob` rows whose `file_version` no longer matches
+/// `current_version` (v0.0.2 spec §5) — the sibling of [`stale_cache_ids`]
+/// for the `images` table, joining the same post-pull eviction step (see
+/// this section's own note above — cache and image eviction are both
+/// version-triggered, not file-sweep-triggered).
+pub fn stale_image_ids<R: fold::stream::Readable>(
+    images: &fold::pipeline::terminal::TableReader<'_, R, String, crate::model::ImageBlobRec>,
+    current_version: &str,
+) -> Vec<Id> {
+    images
+        .iter()
+        .filter(|(_, rec)| rec.file_version != current_version)
+        .map(|(k, _)| Id::ImageBlob(k))
+        .collect()
+}
+
+/// Remove `stale` rows in one write transaction. Never touches variables,
+/// collections, or the meta row — pass only ids gathered by
+/// [`stale_cache_ids`] and/or [`stale_image_ids`], the only two sources
+/// that feed this (both version-triggered, not file-sweep-triggered — see
+/// this section's own note above).
 pub fn evict_stale_cache<P: Push<Keyed<Id, Rec>>>(st: &mut KeyedStream<Id, Rec, P>, stale: &[Id]) {
     st.wtx(|tx| {
         for id in stale {
-            debug_assert!(matches!(id, Id::ProxyCache(_)));
+            debug_assert!(matches!(id, Id::ProxyCache(_) | Id::ImageBlob(_)));
             tx.remove(id);
         }
     });
@@ -358,8 +386,12 @@ pub fn evict_stale_cache<P: Push<Keyed<Id, Rec>>>(st: &mut KeyedStream<Id, Rec, 
 // component_sets/styles table readers, never `mirror_config` — this is a
 // structural property of that function's own argument list, not a runtime
 // check, so there's nothing to `debug_assert` against inside `sync` for it
-// (unlike `evict_stale_cache`'s `ProxyCache`-only assertion, which guards a
-// *caller-supplied* id list against passing the wrong table).
+// (unlike `evict_stale_cache`'s id-kind assertion, which guards a
+// *caller-supplied* id list against passing the wrong table). `images`
+// (v0.0.2 spec §5) is exempt from the same sweep for the identical
+// reason — it's a fourth table `collect_sweepable` never reads from —
+// and, like `proxy_cache`, has its own version-triggered eviction path
+// instead ([`stale_image_ids`] / [`evict_stale_cache`]).
 
 /// Read the stored geometry flag ([`MirrorConfigRec::geometry`]), or
 /// `false` when no row has ever been upserted (every pre-v0.0.2 store, and
@@ -419,11 +451,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut st = crate::open_store!(&dir.path().join("db"));
 
-        let absent = st.rtx(|(.., mirror_config)| read_geometry(&mirror_config));
+        let absent = st.rtx(|(.., mirror_config, _)| read_geometry(&mirror_config));
         assert!(!absent, "no row upserted yet ⇒ geometry defaults false");
 
         upsert_mirror_config(&mut st, true);
-        let now_true = st.rtx(|(.., mirror_config)| read_geometry(&mirror_config));
+        let now_true = st.rtx(|(.., mirror_config, _)| read_geometry(&mirror_config));
         assert!(now_true, "the upserted flag must be what a later read sees");
 
         // Sweep-exempt: `mirror_config` isn't among `collect_sweepable`'s
@@ -441,7 +473,7 @@ mod tests {
             collect_sweepable(&nodes, &components, &component_sets, &styles)
         });
         sync(&mut st, &prior, &flattened, 0);
-        let still_true = st.rtx(|(.., mirror_config)| read_geometry(&mirror_config));
+        let still_true = st.rtx(|(.., mirror_config, _)| read_geometry(&mirror_config));
         assert!(still_true, "mirror_config must survive an unrelated sweep");
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -11,7 +11,7 @@ use fold::stream::KeyedStream;
 use serde::Serialize;
 
 use crate::flatten::Flattened;
-use crate::model::{FileMeta, Id, NodeRec, ProxyCacheRec, Rec};
+use crate::model::{FileMeta, Id, MirrorConfigRec, NodeRec, ProxyCacheRec, Rec};
 
 // ---- pipeline branch functions (pure; fold requires determinism) ----
 
@@ -132,6 +132,15 @@ pub fn meta_only(d: &Keyed<Id, Rec>) -> Option<Keyed<u8, FileMeta>> {
     }
 }
 
+/// Feeds the `mirror_config` table: the single [`MirrorConfigRec`] row
+/// (v0.0.2 spec §4), keyed by `0u8` — same reasoning as [`meta_only`].
+pub fn mirror_config_only(d: &Keyed<Id, Rec>) -> Option<Keyed<u8, MirrorConfigRec>> {
+    match &d.val {
+        Rec::MirrorConfig(m) => Some(Keyed::new(0u8, m.clone())),
+        _ => None,
+    }
+}
+
 /// The full figmog pipeline. Sink names are frozen on-disk schema.
 #[macro_export]
 macro_rules! figmog_pipeline {
@@ -186,6 +195,10 @@ macro_rules! figmog_pipeline {
             FilterMap::new(
                 $crate::store::proxy_cache_only,
                 terminal::Table::new("proxy_cache"),
+            ),
+            FilterMap::new(
+                $crate::store::mirror_config_only,
+                terminal::Table::new("mirror_config"),
             ),
         )
     }};
@@ -336,4 +349,99 @@ pub fn evict_stale_cache<P: Push<Keyed<Id, Rec>>>(st: &mut KeyedStream<Id, Rec, 
             tx.remove(id);
         }
     });
+}
+
+// ---- sticky vector geometry (v0.0.2 spec §4) ----
+//
+// `mirror_config` is exempt from `sync`'s sweep the same way `meta` is:
+// `collect_sweepable` (above) draws only from the nodes/components/
+// component_sets/styles table readers, never `mirror_config` — this is a
+// structural property of that function's own argument list, not a runtime
+// check, so there's nothing to `debug_assert` against inside `sync` for it
+// (unlike `evict_stale_cache`'s `ProxyCache`-only assertion, which guards a
+// *caller-supplied* id list against passing the wrong table).
+
+/// Read the stored geometry flag ([`MirrorConfigRec::geometry`]), or
+/// `false` when no row has ever been upserted (every pre-v0.0.2 store, and
+/// any store never pulled with `--geometry`).
+pub fn read_geometry<R: fold::stream::Readable>(
+    cfg: &fold::pipeline::terminal::TableReader<'_, R, u8, MirrorConfigRec>,
+) -> bool {
+    cfg.get(&0).map(|c| c.geometry).unwrap_or(false)
+}
+
+/// Upsert the sticky geometry flag in its own write transaction — a
+/// separate `wtx` from `sync`'s (mirroring `evict_stale_cache`'s own
+/// separation, see that section's note above): this is config bookkeeping
+/// about the *pull itself*, not part of the flattened file's record set
+/// `sync` reconciles.
+pub fn upsert_mirror_config<P: Push<Keyed<Id, Rec>>>(
+    st: &mut KeyedStream<Id, Rec, P>,
+    geometry: bool,
+) {
+    st.wtx(|tx| {
+        tx.upsert(
+            &Id::MirrorConfig,
+            &Rec::MirrorConfig(MirrorConfigRec { geometry }),
+        );
+    });
+}
+
+/// What a pull should request from Figma, given this call's own override
+/// (`--geometry` / `figmog_open`'s `geometry` arg / a plain re-pull's
+/// implicit `false`) and whatever's already stored: once either side is
+/// `true`, geometry stays on (spec §4 — sticky; the documented way back
+/// off is `pull --fresh`, whose callers pass `stored = false` here without
+/// even reading the about-to-be-wiped store).
+pub fn effective_geometry(flag: bool, stored: bool) -> bool {
+    flag || stored
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_geometry_is_sticky_once_either_side_is_true() {
+        assert!(!effective_geometry(false, false));
+        assert!(effective_geometry(true, false));
+        assert!(effective_geometry(false, true));
+        assert!(effective_geometry(true, true));
+    }
+
+    /// Store-level proof that the stored flag alone drives a later pull's
+    /// choice (spec §4 stickiness): absent config reads `false`, an upsert
+    /// makes it stick, and reading it again — the exact shape
+    /// `cli::pull::do_pull`/`sessions::open_session_at`'s pull closure both
+    /// perform before deciding what to request — reflects the write.
+    #[test]
+    fn mirror_config_defaults_false_and_persists_once_upserted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut st = crate::open_store!(&dir.path().join("db"));
+
+        let absent = st.rtx(|(.., mirror_config)| read_geometry(&mirror_config));
+        assert!(!absent, "no row upserted yet ⇒ geometry defaults false");
+
+        upsert_mirror_config(&mut st, true);
+        let now_true = st.rtx(|(.., mirror_config)| read_geometry(&mirror_config));
+        assert!(now_true, "the upserted flag must be what a later read sees");
+
+        // Sweep-exempt: `mirror_config` isn't among `collect_sweepable`'s
+        // sources, so an ordinary `sync` sweep (even one whose live set is
+        // empty) must never remove it — mirroring `meta`'s own exemption.
+        let flattened = Flattened {
+            recs: Vec::new(),
+            file: crate::flatten::FileInfo {
+                name: "F".into(),
+                version: "1".into(),
+                last_modified: "t".into(),
+            },
+        };
+        let prior = st.rtx(|((nodes, ..), components, component_sets, styles, ..)| {
+            collect_sweepable(&nodes, &components, &component_sets, &styles)
+        });
+        sync(&mut st, &prior, &flattened, 0);
+        let still_true = st.rtx(|(.., mirror_config)| read_geometry(&mirror_config));
+        assert!(still_true, "mirror_config must survive an unrelated sweep");
+    }
 }

--- a/src/vars.rs
+++ b/src/vars.rs
@@ -146,17 +146,26 @@ pub fn infer_from_nodes<'a>(nodes: impl Iterator<Item = &'a NodeRec>) -> Vec<Var
         .collect()
 }
 
+/// The raw-JSON pointer prefix a style type's definition lives under on a
+/// consumer node, shared by [`style_value_from_consumer`] (the definition
+/// itself) and `query::styles`'s `resolve_vars` path (which variable
+/// bindings belong to that definition — a binding's own pointer, e.g.
+/// `/fills/0/color`, starts with this prefix).
+pub fn style_value_pointer(style_type: &str) -> Option<&'static str> {
+    match style_type {
+        "TEXT" => Some("/style"),
+        "FILL" => Some("/fills"),
+        "EFFECT" => Some("/effects"),
+        "GRID" => Some("/layoutGrids"),
+        _ => None,
+    }
+}
+
 /// Derive a style's definition from one consumer node's raw JSON.
 /// Style definitions are not in the file JSON; consumers carry the
 /// resolved properties.
 pub fn style_value_from_consumer(style_type: &str, consumer_raw: &str) -> Option<Value> {
     let raw: Value = serde_json::from_str(consumer_raw).ok()?;
-    let pointer = match style_type {
-        "TEXT" => "/style",
-        "FILL" => "/fills",
-        "EFFECT" => "/effects",
-        "GRID" => "/layoutGrids",
-        _ => return None,
-    };
+    let pointer = style_value_pointer(style_type)?;
     raw.pointer(pointer).cloned()
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -84,7 +84,7 @@ mod tests {
                 .pop()
                 .expect("unexpected extra file_meta call")
         }
-        fn file(&self, _key: &str) -> Result<serde_json::Value, ApiError> {
+        fn file(&self, _key: &str, _geometry: bool) -> Result<serde_json::Value, ApiError> {
             panic!("watcher must never fetch the file itself");
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1383,3 +1383,22 @@ fn images_with_no_established_mirror_fails_like_every_other_command() {
     let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
     assert!(stderr.contains("no mirror here"), "stderr: {stderr}");
 }
+
+/// `figmog images` with zero ids is a clap usage error, not a runtime one
+/// (matching the `figmog_images` tool's own explicit `` `ids` must not be
+/// empty `` rejection in `dispatch::require_str_array`) — never gets far
+/// enough to open a store or hit the network.
+#[test]
+fn images_with_no_ids_is_rejected_by_clap() {
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["images"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(
+        stderr.to_lowercase().contains("required")
+            || stderr.to_lowercase().contains("the following required"),
+        "expected clap to reject a missing required `ids` argument: {stderr}"
+    );
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -375,8 +375,9 @@ fn import_variables_output_shape_is_the_variable_count_alone() {
 
 /// M6 (spec §4 debt ledger): `figmog tools`' JSON output shape — an array
 /// with one `{name, source, cacheable}` row per tool, nothing more.
-/// `--no-upstream` keeps this offline and deterministic: exactly the 19
-/// local `figmog_*` tools, every one `source: "local"`.
+/// `--no-upstream` keeps this offline and deterministic: exactly the 20
+/// local `figmog_*` tools (v0.0.2 §2 added `figmog_subtree`), every one
+/// `source: "local"`.
 #[test]
 fn tools_output_shape_is_name_source_cacheable_rows() {
     let out = Command::cargo_bin("figmog")
@@ -386,7 +387,7 @@ fn tools_output_shape_is_name_source_cacheable_rows() {
         .success();
     let v: serde_json::Value = serde_json::from_slice(&out.get_output().stdout).unwrap();
     let rows = v.as_array().expect("tools output is a JSON array");
-    assert_eq!(rows.len(), 19, "19 local figmog_* tools, no upstream");
+    assert_eq!(rows.len(), 20, "20 local figmog_* tools, no upstream");
     for row in rows {
         let obj = row.as_object().expect("each row is a JSON object");
         let keys: std::collections::BTreeSet<&str> = obj.keys().map(String::as_str).collect();
@@ -664,4 +665,310 @@ fn json_flag_is_rejected_as_unknown() {
         stderr.contains("--json") || stderr.to_lowercase().contains("unexpected argument"),
         "expected clap to reject the removed --json flag: {stderr}"
     );
+}
+
+// ---- v0.0.2 §2: subtree dump ----
+
+#[test]
+fn dump_full_raw_json_nested_recursively_with_depth_and_fields_projection() {
+    let (_dir, db) = fixture_db();
+    let run = |args: &[&str]| {
+        let out = Command::cargo_bin("figmog")
+            .unwrap()
+            .args(args)
+            .args(["--db", &db])
+            .assert()
+            .success();
+        serde_json::from_slice::<serde_json::Value>(&out.get_output().stdout).unwrap()
+    };
+
+    // Unbounded depth (default): full raw JSON, children nested in
+    // child-index order.
+    let dump = run(&["dump", "1:1"]);
+    assert_eq!(dump["id"], "1:1");
+    assert_eq!(dump["layoutMode"], "VERTICAL"); // raw field preserved verbatim
+    let kids = dump["children"].as_array().unwrap();
+    assert_eq!(kids.len(), 2);
+    assert_eq!(kids[0]["id"], "1:2"); // Title, numeric child order
+    assert_eq!(kids[0]["characters"], "Welcome to the garden");
+    assert_eq!(kids[1]["id"], "1:3"); // Button
+
+    // depth 0: the node itself only; `children` is still present, just empty.
+    let dump0 = run(&["dump", "1:1", "--depth", "0"]);
+    assert_eq!(dump0["children"], serde_json::json!([]));
+    assert_eq!(dump0["layoutMode"], "VERTICAL");
+
+    // depth 1 from the page: one level down, grandchildren cut off.
+    let dump1 = run(&["dump", "0:1", "--depth", "1"]);
+    let page_kids = dump1["children"].as_array().unwrap();
+    assert_eq!(page_kids.len(), 2); // Hero (1:1), Old badge (1:9)
+    assert_eq!(page_kids[0]["id"], "1:1");
+    assert_eq!(
+        page_kids[0]["children"],
+        serde_json::json!([]),
+        "depth exhausted before Hero's own children"
+    );
+
+    // fields projection: only requested fields plus the always-kept set
+    // (id/name/type/children) survive.
+    let projected = run(&["dump", "1:1", "--fields", "layoutMode"]);
+    let keys: std::collections::BTreeSet<&str> = projected
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        keys,
+        ["id", "name", "type", "children", "layoutMode"]
+            .into_iter()
+            .collect(),
+        "fields projection keeps id/name/type/children always, plus requested fields"
+    );
+    assert_eq!(
+        projected["children"][0]["layoutMode"],
+        serde_json::Value::Null
+    );
+
+    // Unknown field names are silently absent, not an error.
+    let unknown = run(&["dump", "1:1", "--fields", "notAField"]);
+    assert!(!unknown.as_object().unwrap().contains_key("notAField"));
+    assert_eq!(unknown["id"], "1:1"); // still always-kept
+}
+
+#[test]
+fn dump_unknown_node_fails_cleanly() {
+    let (_dir, db) = fixture_db();
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["dump", "99:99", "--db", &db])
+        .assert()
+        .failure()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(stderr.contains("99:99"), "stderr: {stderr}");
+}
+
+// ---- v0.0.2 §3: --under subtree scoping ----
+
+#[test]
+fn under_scopes_find_text_search_where_and_intersects_with_page() {
+    let (_dir, db) = fixture_db();
+    let run = |args: &[&str]| {
+        let out = Command::cargo_bin("figmog")
+            .unwrap()
+            .args(args)
+            .args(["--db", &db])
+            .assert()
+            .success();
+        serde_json::from_slice::<serde_json::Value>(&out.get_output().stdout).unwrap()
+    };
+
+    // find --under: COMPONENT nodes live on page 0:2, outside 1:1's subtree.
+    let none = run(&["find", "--type", "COMPONENT", "--under", "1:1"]);
+    assert_eq!(none.as_array().unwrap().len(), 0);
+
+    // --under is inclusive of the scope root itself.
+    let inclusive = run(&["find", "--type", "FRAME", "--under", "1:1"]);
+    assert_eq!(inclusive.as_array().unwrap().len(), 1);
+    assert_eq!(inclusive[0]["id"], "1:1");
+
+    // text --under narrows to one page's subtree.
+    let text_under = run(&["text", "--under", "1:1"]);
+    assert_eq!(text_under.as_array().unwrap().len(), 1);
+    assert_eq!(text_under[0]["id"], "1:2");
+    let text_elsewhere = run(&["text", "--under", "2:1"]); // Button component set: no TEXT nodes
+    assert_eq!(text_elsewhere.as_array().unwrap().len(), 0);
+
+    // search --under.
+    let search_under = run(&["search", "garden", "--under", "1:1"]);
+    assert_eq!(search_under[0]["id"], "1:2");
+    let search_outside = run(&["search", "garden", "--under", "0:2"]);
+    assert_eq!(search_outside.as_array().unwrap().len(), 0);
+
+    // where --under.
+    let where_under = run(&[
+        "where",
+        "--pointer",
+        "/layoutMode",
+        "--equals",
+        "VERTICAL",
+        "--under",
+        "1:1",
+    ]);
+    assert_eq!(where_under.as_array().unwrap().len(), 1);
+    let where_outside = run(&[
+        "where",
+        "--pointer",
+        "/layoutMode",
+        "--equals",
+        "VERTICAL",
+        "--under",
+        "0:2",
+    ]);
+    assert_eq!(where_outside.as_array().unwrap().len(), 0);
+
+    // --under intersects with --page: page 0:2's TEXT nodes scoped under
+    // page 0:1's subtree is the empty intersection.
+    let intersected = run(&["find", "--type", "TEXT", "--page", "0:2", "--under", "0:1"]);
+    assert_eq!(
+        intersected.as_array().unwrap().len(),
+        0,
+        "page and under compose by intersection"
+    );
+}
+
+#[test]
+fn under_unknown_id_errors_cleanly() {
+    let (_dir, db) = fixture_db();
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["find", "--type", "TEXT", "--under", "99:99", "--db", &db])
+        .assert()
+        .failure()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(stderr.contains("99:99"), "stderr: {stderr}");
+}
+
+// ---- v0.0.2 §6: --resolve-vars ----
+
+#[test]
+fn resolve_vars_marks_bindings_unresolved_with_no_variables_table() {
+    let (_dir, db) = fixture_db();
+
+    // No import: both of 1:1's bound variables (fill color, paddingLeft)
+    // have no entry in the (empty) variables table.
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["get", "1:1", "--resolve-vars", "--db", &db])
+        .assert()
+        .success();
+    let v: serde_json::Value = serde_json::from_slice(&out.get_output().stdout).unwrap();
+    let resolved = v["resolved_variables"].as_array().unwrap();
+    assert_eq!(resolved.len(), 2);
+    for entry in resolved {
+        assert_eq!(entry["source"], "unresolved");
+        assert!(
+            entry["variable_id"]
+                .as_str()
+                .unwrap()
+                .starts_with("VariableID:")
+        );
+        assert!(entry.get("variable_name").is_none());
+    }
+}
+
+#[test]
+fn resolve_vars_resolves_imported_variables_on_get_dump_and_styles_values() {
+    let (dir, db) = fixture_db();
+    let export = dir.path().join("vars.json");
+    std::fs::write(&export, include_str!("fixtures/variables-export.json")).unwrap();
+    Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["import-variables", export.to_str().unwrap(), "--db", &db])
+        .assert()
+        .success();
+
+    // `get --resolve-vars`: names + per-mode values from the imported table.
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["get", "1:1", "--resolve-vars", "--db", &db])
+        .assert()
+        .success();
+    let v: serde_json::Value = serde_json::from_slice(&out.get_output().stdout).unwrap();
+    let resolved = v["resolved_variables"].as_array().unwrap();
+    assert_eq!(resolved.len(), 2);
+    let color = resolved
+        .iter()
+        .find(|e| e["variable_id"] == "VariableID:100")
+        .expect("fill color binding present");
+    assert_eq!(color["variable_name"], "color/surface/primary");
+    assert_eq!(color["values_by_mode"]["light"]["r"], 0.06);
+    assert_eq!(color["values_by_mode"]["dark"]["type"], "VARIABLE_ALIAS");
+    let padding = resolved
+        .iter()
+        .find(|e| e["variable_id"] == "VariableID:200")
+        .expect("paddingLeft binding present");
+    assert_eq!(padding["variable_name"], "space/md");
+    assert_eq!(padding["values_by_mode"]["default"], 16.0);
+
+    // `dump --resolve-vars`: same annotation, applied recursively.
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["dump", "1:1", "--resolve-vars", "--db", &db])
+        .assert()
+        .success();
+    let v: serde_json::Value = serde_json::from_slice(&out.get_output().stdout).unwrap();
+    assert_eq!(v["resolved_variables"].as_array().unwrap().len(), 2);
+
+    // `styles --values --resolve-vars`: FILL style S:1's definition comes
+    // from consumer 1:1, whose /fills/0/color binding is VariableID:100 —
+    // paddingLeft (outside /fills) must not leak into this style's list.
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["styles", "--values", "--resolve-vars", "--db", &db])
+        .assert()
+        .success();
+    let styles: serde_json::Value = serde_json::from_slice(&out.get_output().stdout).unwrap();
+    let fill_style = styles
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["style_id"] == "S:1")
+        .expect("FILL style S:1 present");
+    let fill_resolved = fill_style["resolved_variables"].as_array().unwrap();
+    assert_eq!(fill_resolved.len(), 1);
+    assert_eq!(fill_resolved[0]["variable_id"], "VariableID:100");
+    assert_eq!(fill_resolved[0]["variable_name"], "color/surface/primary");
+}
+
+// ---- v0.0.2 §2b: URL-addressed nodes ----
+
+#[test]
+fn get_dump_and_path_accept_a_full_figma_url_as_the_node_id() {
+    let (_dir, db) = fixture_db();
+    let url = "https://www.figma.com/design/flAtUnMfzvA5daBSTFQK35/Fixture?node-id=1-1&t=abc-1";
+
+    let bare = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["get", "1:1", "--db", &db])
+        .assert()
+        .success();
+    let bare: serde_json::Value = serde_json::from_slice(&bare.get_output().stdout).unwrap();
+
+    let via_url = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["get", url, "--db", &db])
+        .assert()
+        .success();
+    let via_url: serde_json::Value = serde_json::from_slice(&via_url.get_output().stdout).unwrap();
+    assert_eq!(
+        bare, via_url,
+        "a frame URL resolves to the same node as its bare id"
+    );
+
+    let dump_via_url = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["dump", url, "--depth", "0", "--db", &db])
+        .assert()
+        .success();
+    let dump_via_url: serde_json::Value =
+        serde_json::from_slice(&dump_via_url.get_output().stdout).unwrap();
+    assert_eq!(dump_via_url["id"], "1:1");
+
+    let path_via_url = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["path", url, "--db", &db])
+        .assert()
+        .success();
+    let path_via_url: serde_json::Value =
+        serde_json::from_slice(&path_via_url.get_output().stdout).unwrap();
+    let ids: Vec<&str> = path_via_url
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["0:0", "0:1", "1:1"]);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -322,6 +322,64 @@ fn parent_cycle_does_not_hang_path_or_stats() {
         .success();
 }
 
+/// The same hand-upserted 2-node mutual-parent construction as
+/// `parent_cycle_does_not_hang_path_or_stats` above also derives a
+/// `children`-multimap cycle (`store::child_edge` feeds `children` off
+/// each node's own `parent_id`, so A:1's parent B:1 and B:1's parent A:1
+/// produce mutual `children` edges too) — `--under`'s BFS
+/// (`query::scope_ids`) must not hang on it, same "runs inside `figmog
+/// serve`'s single-threaded loop" stakes as the parent-cycle case.
+#[test]
+fn children_cycle_does_not_hang_under_scoping() {
+    use figmog::model::{Id, NodeRec, Rec};
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("db");
+    let mut st = figmog::open_store!(&db);
+    let node = |id: &str, parent: &str| NodeRec {
+        id: id.into(),
+        parent_id: Some(parent.into()),
+        child_index: 0,
+        page_id: "0:1".into(),
+        node_type: "FRAME".into(),
+        name: id.into(),
+        visible: true,
+        text: None,
+        component_id: None,
+        component_properties: vec![],
+        property_definitions: None,
+        style_refs: vec![],
+        bound_variables: vec![],
+        abs_bounds: None,
+        raw: "{}".into(),
+    };
+    st.wtx(|tx| {
+        tx.upsert(&Id::Node("A:1".into()), &Rec::Node(node("A:1", "B:1")));
+        tx.upsert(&Id::Node("B:1".into()), &Rec::Node(node("B:1", "A:1")));
+    });
+    drop(st); // release the store lock before the child process opens it
+
+    let db = db.display().to_string();
+
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["find", "--type", "FRAME", "--under", "A:1", "--db", &db])
+        .assert()
+        .success();
+    let v: serde_json::Value = serde_json::from_slice(&out.get_output().stdout).unwrap();
+    let ids: Vec<&str> = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["A:1", "B:1"],
+        "BFS terminates and still finds both cyclic nodes"
+    );
+}
+
 #[test]
 fn import_variables_upgrades_vars_to_authoritative() {
     let (dir, db) = fixture_db();
@@ -831,6 +889,97 @@ fn under_unknown_id_errors_cleanly() {
     assert!(stderr.contains("99:99"), "stderr: {stderr}");
 }
 
+/// Review fix I1: `search --under` must rank the *entire* matching corpus
+/// before truncating to `limit`, not truncate to the global top-`limit`
+/// and filter afterward — otherwise a tight limit under a scope that
+/// contains a real (if globally lower-ranked) match silently returns
+/// nothing. Fixture: five short out-of-scope TEXT nodes named exactly
+/// "garden" (BM25 favors them — an exact, single-term document scores
+/// higher than a longer one containing the term once) rank above the one
+/// in-scope node whose text merely *contains* "garden" among other words.
+#[test]
+fn search_under_ranks_the_full_corpus_before_truncating_to_limit() {
+    let dir = tempfile::tempdir().unwrap();
+    let response = dir.path().join("resp.json");
+    let fixture = serde_json::json!({
+        "name": "SearchUnderFixture",
+        "version": "1",
+        "lastModified": "2026-08-17T00:00:00Z",
+        "document": {
+            "id": "0:0", "name": "Document", "type": "DOCUMENT",
+            "children": [
+                { "id": "0:1", "name": "Page 1", "type": "CANVAS", "children": [
+                    { "id": "1:1", "name": "Scope", "type": "FRAME", "children": [
+                        { "id": "1:2", "name": "Info", "type": "TEXT",
+                          "characters": "A lovely garden path unfolds among tall trees",
+                          "children": [] }
+                    ] }
+                ] },
+                { "id": "0:2", "name": "Page 2", "type": "CANVAS", "children": [
+                    { "id": "2:1", "name": "garden", "type": "TEXT", "children": [] },
+                    { "id": "2:2", "name": "garden", "type": "TEXT", "children": [] },
+                    { "id": "2:3", "name": "garden", "type": "TEXT", "children": [] },
+                    { "id": "2:4", "name": "garden", "type": "TEXT", "children": [] },
+                    { "id": "2:5", "name": "garden", "type": "TEXT", "children": [] }
+                ] }
+            ]
+        },
+        "components": {}, "componentSets": {}, "styles": {}
+    });
+    std::fs::write(&response, serde_json::to_string(&fixture).unwrap()).unwrap();
+    let db = dir.path().join("db").display().to_string();
+    Command::cargo_bin("figmog")
+        .unwrap()
+        .args([
+            "pull",
+            "--from-file",
+            response.to_str().unwrap(),
+            "--db",
+            &db,
+        ])
+        .assert()
+        .success();
+
+    let run = |args: &[&str]| {
+        let out = Command::cargo_bin("figmog")
+            .unwrap()
+            .args(args)
+            .args(["--db", &db])
+            .assert()
+            .success();
+        serde_json::from_slice::<serde_json::Value>(&out.get_output().stdout).unwrap()
+    };
+
+    // Premise check: unscoped top-1 is an out-of-scope short match, not
+    // the in-scope one — otherwise this fixture doesn't reproduce I1.
+    let unscoped = run(&["search", "garden", "-n", "1"]);
+    assert_ne!(
+        unscoped[0]["id"], "1:2",
+        "premise: the in-scope match must rank below the out-of-scope ones globally"
+    );
+
+    // The reviewer's exact repro shape: a tight limit under a scope whose
+    // only match is globally outranked must still return it, not [].
+    let scoped = run(&["search", "garden", "-n", "1", "--under", "1:1"]);
+    let ids: Vec<&str> = scoped
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["1:2"],
+        "scoped search ranks the full corpus before truncating"
+    );
+
+    // A wider limit that still fits inside the scope: same single hit,
+    // nothing else under 1:1 matches "garden".
+    let scoped_wide = run(&["search", "garden", "-n", "5", "--under", "1:1"]);
+    assert_eq!(scoped_wide.as_array().unwrap().len(), 1);
+    assert_eq!(scoped_wide[0]["id"], "1:2");
+}
+
 // ---- v0.0.2 §6: --resolve-vars ----
 
 #[test]
@@ -971,4 +1120,31 @@ fn get_dump_and_path_accept_a_full_figma_url_as_the_node_id() {
         .map(|r| r["id"].as_str().unwrap())
         .collect();
     assert_eq!(ids, vec!["0:0", "0:1", "1:1"]);
+}
+
+/// Review fix I2: `--page` is a node-id argument too (a page id), and
+/// hadn't been routed through the same URL-aware normalization as
+/// `id`/`under`/`target` — a pasted Figma URL silently matched nothing.
+#[test]
+fn page_argument_accepts_a_full_figma_url() {
+    let (_dir, db) = fixture_db();
+    let run = |args: &[&str]| {
+        let out = Command::cargo_bin("figmog")
+            .unwrap()
+            .args(args)
+            .args(["--db", &db])
+            .assert()
+            .success();
+        serde_json::from_slice::<serde_json::Value>(&out.get_output().stdout).unwrap()
+    };
+
+    let bare = run(&["find", "--type", "TEXT", "--page", "0:1"]);
+    let url = "https://www.figma.com/design/flAtUnMfzvA5daBSTFQK35/Fixture?node-id=0-1&t=abc-1";
+    let via_url = run(&["find", "--type", "TEXT", "--page", url]);
+    assert_eq!(
+        bare, via_url,
+        "a page URL matches the same rows as its bare id"
+    );
+    assert_eq!(bare.as_array().unwrap().len(), 1);
+    assert_eq!(bare[0]["id"], "1:2");
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -152,7 +152,7 @@ fn pull_geometry_flag_is_sticky_across_a_later_plain_pull() {
         .success();
     {
         let st = figmog::open_store!(&db_path);
-        let stored = st.rtx(|(.., mirror_config)| figmog::store::read_geometry(&mirror_config));
+        let stored = st.rtx(|(.., mirror_config, _)| figmog::store::read_geometry(&mirror_config));
         assert!(stored, "the --geometry pull must persist the flag");
     }
 
@@ -170,7 +170,7 @@ fn pull_geometry_flag_is_sticky_across_a_later_plain_pull() {
     {
         let st = figmog::open_store!(&db_path);
         let still_stored =
-            st.rtx(|(.., mirror_config)| figmog::store::read_geometry(&mirror_config));
+            st.rtx(|(.., mirror_config, _)| figmog::store::read_geometry(&mirror_config));
         assert!(still_stored, "a plain re-pull must not turn geometry off");
     }
 }
@@ -216,7 +216,7 @@ fn pull_fresh_turns_geometry_back_off() {
         .success();
 
     let st = figmog::open_store!(&db_path);
-    let stored = st.rtx(|(.., mirror_config)| figmog::store::read_geometry(&mirror_config));
+    let stored = st.rtx(|(.., mirror_config, _)| figmog::store::read_geometry(&mirror_config));
     assert!(!stored, "--fresh must reset the sticky geometry flag");
 }
 
@@ -583,9 +583,9 @@ fn import_variables_output_shape_is_the_variable_count_alone() {
 
 /// M6 (spec §4 debt ledger): `figmog tools`' JSON output shape — an array
 /// with one `{name, source, cacheable}` row per tool, nothing more.
-/// `--no-upstream` keeps this offline and deterministic: exactly the 20
-/// local `figmog_*` tools (v0.0.2 §2 added `figmog_subtree`), every one
-/// `source: "local"`.
+/// `--no-upstream` keeps this offline and deterministic: exactly the 21
+/// local `figmog_*` tools (v0.0.2 §2 added `figmog_subtree`, §5 added
+/// `figmog_images`), every one `source: "local"`.
 #[test]
 fn tools_output_shape_is_name_source_cacheable_rows() {
     let out = Command::cargo_bin("figmog")
@@ -595,7 +595,7 @@ fn tools_output_shape_is_name_source_cacheable_rows() {
         .success();
     let v: serde_json::Value = serde_json::from_slice(&out.get_output().stdout).unwrap();
     let rows = v.as_array().expect("tools output is a JSON array");
-    assert_eq!(rows.len(), 20, "20 local figmog_* tools, no upstream");
+    assert_eq!(rows.len(), 21, "21 local figmog_* tools, no upstream");
     for row in rows {
         let obj = row.as_object().expect("each row is a JSON object");
         let keys: std::collections::BTreeSet<&str> = obj.keys().map(String::as_str).collect();
@@ -750,7 +750,7 @@ fn cli_pull_evicts_stale_cache_rows_on_version_change() {
             &serde_json::json!({"cached": true}),
         )
         .unwrap();
-        let hit = st.rtx(|(_, _, _, _, _, _, _, cache_reader, _)| {
+        let hit = st.rtx(|(_, _, _, _, _, _, _, cache_reader, _, _)| {
             cache::lookup(&cache_reader, "get_code", "{}", "100")
         });
         assert!(
@@ -780,7 +780,7 @@ fn cli_pull_evicts_stale_cache_rows_on_version_change() {
         .success();
 
     let st = figmog::open_store!(&db);
-    let evicted = st.rtx(|(_, _, _, _, _, _, _, cache_reader, _)| {
+    let evicted = st.rtx(|(_, _, _, _, _, _, _, cache_reader, _, _)| {
         cache::lookup(&cache_reader, "get_code", "{}", "100")
     });
     assert_eq!(
@@ -1297,4 +1297,89 @@ fn page_argument_accepts_a_full_figma_url() {
     );
     assert_eq!(bare.as_array().unwrap().len(), 1);
     assert_eq!(bare[0]["id"], "1:2");
+}
+
+// ---- figmog images (v0.0.2 spec §5) ----
+//
+// No automated live-network test anywhere in this crate's suite (spec §5;
+// see `images.rs`'s own module doc comment): `images::resolve`'s own unit
+// tests already exercise the full render/fill/eviction orchestration
+// against a scripted `FigmaApi` fake, so these e2e tests only need to
+// prove the CLI's offline-reachable surface — no serve running, no
+// FIGMA_TOKEN, socket routing never engaged.
+
+/// A mirror is established (`pull --from-file`, no network), but no
+/// FIGMA_TOKEN is set and no serve is running: every requested id is a
+/// cache miss, so `figmog images` must still print a manifest-shaped JSON
+/// array on stdout (never the generic `{"error": ...}` shape) with a
+/// per-item error naming FIGMA_TOKEN, and exit 1 (spec §5: partial/zero
+/// success is still manifest output, exit reflects success count alone).
+#[test]
+fn images_no_token_error_path_is_manifest_shaped_json_exit_1() {
+    let dir = tempfile::tempdir().unwrap();
+    let response = dir.path().join("resp.json");
+    std::fs::write(
+        &response,
+        serde_json::to_string(&common::fixture_v1()).unwrap(),
+    )
+    .unwrap();
+
+    Command::cargo_bin("figmog")
+        .unwrap()
+        .current_dir(dir.path())
+        .args([
+            "pull",
+            "flAtUnMfzvA5daBSTFQK35",
+            "--from-file",
+            response.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .current_dir(dir.path())
+        .env_remove("FIGMA_TOKEN")
+        .args(["images", "1:2", "--no-socket"])
+        .assert()
+        .failure()
+        .code(1);
+
+    let stdout = out.get_output().stdout.clone();
+    let v: serde_json::Value = serde_json::from_slice(&stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout not JSON: {e}\nstdout: {}",
+            String::from_utf8_lossy(&stdout)
+        )
+    });
+    let rows = v.as_array().expect("manifest is a JSON array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], "1:2");
+    assert_eq!(rows[0]["kind"], "render");
+    assert_eq!(rows[0]["cached"], false);
+    let error = rows[0]["error"].as_str().expect("error field present");
+    assert!(error.contains("FIGMA_TOKEN"), "error: {error}");
+    assert!(
+        rows[0].get("path").is_none(),
+        "nothing was written: {rows:?}"
+    );
+}
+
+/// A well-formed-looking file key with no established mirror at all: the
+/// CLI's own `resolve_db` fails before `cmd_images` is ever reached —
+/// still exit 1, but the generic `{"error": ...}` shape (no mirror to
+/// build a per-item manifest against), on stderr like every other command
+/// missing a mirror.
+#[test]
+fn images_with_no_established_mirror_fails_like_every_other_command() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["images", "1:2"])
+        .assert()
+        .failure()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&out.get_output().stderr).to_string();
+    assert!(stderr.contains("no mirror here"), "stderr: {stderr}");
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -70,6 +70,156 @@ fn pull_from_file_reports_churn_and_is_idempotent() {
     assert_eq!(v["added"], 0);
 }
 
+// ---- sticky vector geometry (v0.0.2 spec §4) ----
+
+/// `pull --geometry` with a fixture that carries `fillGeometry` (what a
+/// real `?geometry=paths` fetch would return on a vector node) keeps that
+/// data in the node's raw JSON — `flatten`'s `raw` field is unknown-field-
+/// preserving, so this is really proving the CLI plumbing (the flag
+/// doesn't get stripped or cause an error) rather than the network
+/// request itself, which `--from-file` never issues (see
+/// `figmog::api::file_url`'s own unit tests for that half).
+#[test]
+fn pull_geometry_flag_keeps_fill_geometry_in_raw() {
+    let dir = tempfile::tempdir().unwrap();
+    let response = dir.path().join("resp.json");
+    std::fs::write(
+        &response,
+        serde_json::to_string(&common::fixture_with_geometry()).unwrap(),
+    )
+    .unwrap();
+    let db = dir.path().join("db").display().to_string();
+
+    Command::cargo_bin("figmog")
+        .unwrap()
+        .args([
+            "pull",
+            "--from-file",
+            response.to_str().unwrap(),
+            "--geometry",
+            "--db",
+            &db,
+        ])
+        .assert()
+        .success();
+
+    let out = Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["get", "1:1", "--db", &db])
+        .assert()
+        .success();
+    let node: serde_json::Value = serde_json::from_slice(&out.get_output().stdout).unwrap();
+    assert!(
+        node["fillGeometry"].is_array(),
+        "fillGeometry must survive into raw: {node}"
+    );
+}
+
+/// The stored half of stickiness (spec §4): a `--geometry` pull persists
+/// the flag, and a later *plain* re-pull (no `--geometry`) must not clear
+/// it. The actual network request choice this drives is proven separately
+/// and purely (`store::tests::effective_geometry_is_sticky_once_either_
+/// side_is_true`, `api::tests::file_url_adds_geometry_paths_only_when_
+/// requested`) — `--from-file` never issues a request to inspect, so this
+/// test proves the persisted config survives an ordinary re-pull
+/// end-to-end instead. Reads the stored config directly off the store
+/// (there's no CLI-surfaced way to read `mirror_config`), dropping each
+/// handle before the next `figmog` subprocess reopens the same store —
+/// fjall allows only one open per store per process at a time.
+#[test]
+fn pull_geometry_flag_is_sticky_across_a_later_plain_pull() {
+    let dir = tempfile::tempdir().unwrap();
+    let response = dir.path().join("resp.json");
+    std::fs::write(
+        &response,
+        serde_json::to_string(&common::fixture_v1()).unwrap(),
+    )
+    .unwrap();
+    let db_path = dir.path().join("db");
+    let db = db_path.display().to_string();
+
+    Command::cargo_bin("figmog")
+        .unwrap()
+        .args([
+            "pull",
+            "--from-file",
+            response.to_str().unwrap(),
+            "--geometry",
+            "--db",
+            &db,
+        ])
+        .assert()
+        .success();
+    {
+        let st = figmog::open_store!(&db_path);
+        let stored = st.rtx(|(.., mirror_config)| figmog::store::read_geometry(&mirror_config));
+        assert!(stored, "the --geometry pull must persist the flag");
+    }
+
+    Command::cargo_bin("figmog")
+        .unwrap()
+        .args([
+            "pull",
+            "--from-file",
+            response.to_str().unwrap(),
+            "--db",
+            &db,
+        ])
+        .assert()
+        .success();
+    {
+        let st = figmog::open_store!(&db_path);
+        let still_stored =
+            st.rtx(|(.., mirror_config)| figmog::store::read_geometry(&mirror_config));
+        assert!(still_stored, "a plain re-pull must not turn geometry off");
+    }
+}
+
+/// The documented way back off (spec §4): `--fresh` wipes the store, so a
+/// subsequent plain pull's config starts over at `false`.
+#[test]
+fn pull_fresh_turns_geometry_back_off() {
+    let dir = tempfile::tempdir().unwrap();
+    let response = dir.path().join("resp.json");
+    std::fs::write(
+        &response,
+        serde_json::to_string(&common::fixture_v1()).unwrap(),
+    )
+    .unwrap();
+    let db_path = dir.path().join("db");
+    let db = db_path.display().to_string();
+
+    Command::cargo_bin("figmog")
+        .unwrap()
+        .args([
+            "pull",
+            "--from-file",
+            response.to_str().unwrap(),
+            "--geometry",
+            "--db",
+            &db,
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("figmog")
+        .unwrap()
+        .args([
+            "pull",
+            "--from-file",
+            response.to_str().unwrap(),
+            "--fresh",
+            "--db",
+            &db,
+        ])
+        .assert()
+        .success();
+
+    let st = figmog::open_store!(&db_path);
+    let stored = st.rtx(|(.., mirror_config)| figmog::store::read_geometry(&mirror_config));
+    assert!(!stored, "--fresh must reset the sticky geometry flag");
+}
+
 #[test]
 fn status_pages_tree_get_find() {
     let (_dir, db) = fixture_db();
@@ -600,7 +750,7 @@ fn cli_pull_evicts_stale_cache_rows_on_version_change() {
             &serde_json::json!({"cached": true}),
         )
         .unwrap();
-        let hit = st.rtx(|(_, _, _, _, _, _, _, cache_reader)| {
+        let hit = st.rtx(|(_, _, _, _, _, _, _, cache_reader, _)| {
             cache::lookup(&cache_reader, "get_code", "{}", "100")
         });
         assert!(
@@ -630,7 +780,7 @@ fn cli_pull_evicts_stale_cache_rows_on_version_change() {
         .success();
 
     let st = figmog::open_store!(&db);
-    let evicted = st.rtx(|(_, _, _, _, _, _, _, cache_reader)| {
+    let evicted = st.rtx(|(_, _, _, _, _, _, _, cache_reader, _)| {
         cache::lookup(&cache_reader, "get_code", "{}", "100")
     });
     assert_eq!(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -127,6 +127,24 @@ pub fn fixture_other() -> Value {
     })
 }
 
+/// [`fixture_v1`] with `fillGeometry`/`strokeGeometry` path data added to
+/// the Hero frame (`1:1`) — what a real `GET /v1/files/:key?geometry=paths`
+/// response carries on vector nodes (v0.0.2 spec §4) but a plain fetch
+/// omits. Used to prove `pull --geometry` keeps this data in `raw`; a
+/// synthetic stand-in, since the `--from-file` path this crate's tests use
+/// never actually issues the network request that decides whether it's
+/// present (see `api::file_url`'s own unit tests for that half).
+#[allow(dead_code)]
+pub fn fixture_with_geometry() -> Value {
+    let mut v = fixture_v1();
+    let hero = &mut v["document"]["children"][0]["children"][0];
+    hero["fillGeometry"] = json!([
+        {"path": "M0,0L800,0L800,400L0,400Z", "windingRule": "NONZERO"}
+    ]);
+    hero["strokeGeometry"] = json!([]);
+    v
+}
+
 /// Materialize [`fixture_v1`] into a DB via `pull --from-file` and return the
 /// (tempdir, db-path) pair every read command — CLI or `serve` — needs.
 /// Shared so `tests/cli.rs` and `tests/serve.rs` build the same fixture the

--- a/tests/enterprise_vars.rs
+++ b/tests/enterprise_vars.rs
@@ -70,6 +70,7 @@ fn enterprise_export_syncs_with_zero_churn_on_identical_repull() {
             _,
             _,
             _,
+            _,
         )| {
             let mut p = collect_sweepable(&nodes, &components, &component_sets, &styles);
             p.extend(collect_variable_ids(&variables, &variable_collections));
@@ -102,7 +103,7 @@ fn variable_removed_upstream_is_swept_when_export_present() {
         collect_sweepable(&nodes, &components, &component_sets, &styles)
     });
     sync(&mut st, &prior, &flattened, 1_000);
-    st.rtx(|(_, _, _, _, variables, _, _, _, _)| {
+    st.rtx(|(_, _, _, _, variables, _, _, _, _, _)| {
         assert_eq!(variables.iter().count(), 3);
     });
 
@@ -130,6 +131,7 @@ fn variable_removed_upstream_is_swept_when_export_present() {
             _,
             _,
             _,
+            _,
         )| {
             let mut p = collect_sweepable(&nodes, &components, &component_sets, &styles);
             p.extend(collect_variable_ids(&variables, &variable_collections));
@@ -139,7 +141,7 @@ fn variable_removed_upstream_is_swept_when_export_present() {
     let churn = sync(&mut st, &prior2, &flattened2, 2_000);
     assert_eq!(churn.removed, 1, "the dropped variable must be swept");
 
-    st.rtx(|(_, _, _, _, variables, collections, _, _, _)| {
+    st.rtx(|(_, _, _, _, variables, collections, _, _, _, _)| {
         assert!(
             variables.get(&"VariableID:200".to_string()).is_none(),
             "removed-upstream variable must be gone"
@@ -205,7 +207,7 @@ fn imported_variables_survive_pulls_with_no_export() {
     let churn = sync(&mut st, &prior, &flattened2, 2_000);
     assert_eq!(churn.removed, 0, "no export means nothing to sweep");
 
-    st.rtx(|(_, _, _, _, variables, collections, _, _, _)| {
+    st.rtx(|(_, _, _, _, variables, collections, _, _, _, _)| {
         assert!(
             variables.get(&"VariableID:100".to_string()).is_some(),
             "v1 behavior intact: imported variables survive a pull with no Enterprise export"

--- a/tests/enterprise_vars.rs
+++ b/tests/enterprise_vars.rs
@@ -69,6 +69,7 @@ fn enterprise_export_syncs_with_zero_churn_on_identical_repull() {
             variable_collections,
             _,
             _,
+            _,
         )| {
             let mut p = collect_sweepable(&nodes, &components, &component_sets, &styles);
             p.extend(collect_variable_ids(&variables, &variable_collections));
@@ -101,7 +102,7 @@ fn variable_removed_upstream_is_swept_when_export_present() {
         collect_sweepable(&nodes, &components, &component_sets, &styles)
     });
     sync(&mut st, &prior, &flattened, 1_000);
-    st.rtx(|(_, _, _, _, variables, _, _, _)| {
+    st.rtx(|(_, _, _, _, variables, _, _, _, _)| {
         assert_eq!(variables.iter().count(), 3);
     });
 
@@ -128,6 +129,7 @@ fn variable_removed_upstream_is_swept_when_export_present() {
             variable_collections,
             _,
             _,
+            _,
         )| {
             let mut p = collect_sweepable(&nodes, &components, &component_sets, &styles);
             p.extend(collect_variable_ids(&variables, &variable_collections));
@@ -137,7 +139,7 @@ fn variable_removed_upstream_is_swept_when_export_present() {
     let churn = sync(&mut st, &prior2, &flattened2, 2_000);
     assert_eq!(churn.removed, 1, "the dropped variable must be swept");
 
-    st.rtx(|(_, _, _, _, variables, collections, _, _)| {
+    st.rtx(|(_, _, _, _, variables, collections, _, _, _)| {
         assert!(
             variables.get(&"VariableID:200".to_string()).is_none(),
             "removed-upstream variable must be gone"
@@ -203,7 +205,7 @@ fn imported_variables_survive_pulls_with_no_export() {
     let churn = sync(&mut st, &prior, &flattened2, 2_000);
     assert_eq!(churn.removed, 0, "no export means nothing to sweep");
 
-    st.rtx(|(_, _, _, _, variables, collections, _, _)| {
+    st.rtx(|(_, _, _, _, variables, collections, _, _, _)| {
         assert!(
             variables.get(&"VariableID:100".to_string()).is_some(),
             "v1 behavior intact: imported variables survive a pull with no Enterprise export"

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -330,6 +330,23 @@ fn serve_e2e_initialize_tools_list_and_tool_calls() {
     let resp = call(&mut stdin, &rx, 8, "figmog_nonexistent", json!({}));
     assert_eq!(resp["result"]["isError"], json!(true));
 
+    // -- figmog_node with a malformed percent-escape (`%` + one byte + a
+    // multibyte UTF-8 char) in a node-id URL: isError, not a process death
+    // (F1 regression — `ident::percent_decode` used to panic slicing a
+    // multibyte char mid-byte, and this loop has no per-call unwind guard,
+    // so one malformed frame used to abort the whole server). Answering
+    // this call at all — rather than the client's `recv` timing out because
+    // the process died — is the assertion; the exact error text isn't
+    // pinned.
+    let resp = call(
+        &mut stdin,
+        &rx,
+        9,
+        "figmog_node",
+        json!({"id": "https://www.figma.com/file/abc/x?node-id=%aé"}),
+    );
+    assert_eq!(resp["result"]["isError"], json!(true));
+
     // Closing stdin is what makes the (`--no-watch`) serve loop exit: its
     // reader thread sees EOF and drops the sender, so the main loop's
     // blocking `rx.recv()` returns `Disconnected` and the process exits 0.
@@ -1315,6 +1332,87 @@ fn no_socket_flag_forces_the_old_lock_error() {
         err.contains("store is locked"),
         "expected the direct-mode lock error, got: {err}"
     );
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
+/// F2 regression: `figmog images` used to socket-route even when `--db`
+/// was given — `cmd_images` gated its socket attempt on `--no-socket`
+/// alone, unlike every other routed command's `cli.db.is_none()` gate
+/// (spec §10: "When neither `--no-socket` nor `--db` is given..."). With
+/// `--db <path>`, `resolve_db` yields `key: None`; before the fix, the
+/// routed call still reached the *running* serve, which would answer
+/// against its own default mirror (`KEY`, not `other_db` at all) —
+/// `fetch_direct`'s own `db.key` check would never even run. After the
+/// fix, `--db` bypasses the socket exactly like `--no-socket` does: the
+/// call goes straight to `fetch_direct`, whose first step needs a
+/// resolved file key and fails immediately with the generic
+/// `{"error": ...}` shape on stderr, before any manifest is built or the
+/// network is touched — the observable proof this test pins, since a
+/// socket-routed answer would instead be a manifest-shaped JSON *array*
+/// on stdout (see the `images_no_token_error_path_is_manifest_shaped_json_exit_1`
+/// CLI test).
+#[test]
+fn images_with_db_flag_bypasses_the_socket_even_when_serve_is_reachable() {
+    const KEY: &str = "figmogsocketkeyfff666";
+    let dir = default_root_fixture(KEY, common::fixture_v1());
+    let (mut guard, mut stdin, rx) = spawn_default_root_serve(dir.path(), KEY, &[]);
+    handshake(&mut stdin, &rx);
+
+    // A second, unrelated store `serve` never opened at all — proves a
+    // wrong-file answer (had the bug still routed this through the
+    // socket) would have come from `KEY`'s mirror, not this one.
+    let other_db = dir.path().join("other-db");
+    let response = dir.path().join("other-resp.json");
+    std::fs::write(
+        &response,
+        serde_json::to_string(&common::fixture_other()).unwrap(),
+    )
+    .unwrap();
+    assert_cmd::Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["pull", "--from-file"])
+        .arg(&response)
+        .arg("--db")
+        .arg(&other_db)
+        .assert()
+        .success();
+
+    let out = assert_cmd::Command::cargo_bin("figmog")
+        .unwrap()
+        .current_dir(dir.path())
+        .env_remove("FIGMA_TOKEN")
+        .args(["images", "1:1", "--db"])
+        .arg(&other_db)
+        .assert()
+        .failure();
+    let output = out.get_output();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        output.stdout.is_empty(),
+        "direct-mode failure short-circuits before any manifest is printed: stdout {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let parsed: Value = serde_json::from_slice(&output.stderr).unwrap_or_else(|e| {
+        panic!(
+            "stderr must be exactly one JSON object (parse error: {e}); stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let err = parsed["error"]
+        .as_str()
+        .unwrap_or_else(|| panic!("expected an \"error\" string field, got: {parsed}"));
+    assert!(
+        err.contains("no file key"),
+        "expected the direct-mode 'no file key' error, proving --db bypassed \
+         the socket instead of getting KEY's default-mirror manifest back: {err}"
+    );
+
+    // serve is still alive and untouched by this call.
+    let resp = call(&mut stdin, &rx, 2, "figmog_status", json!({}));
+    assert_eq!(resp["result"]["isError"], json!(false), "resp: {resp:#?}");
 
     drop(stdin);
     let status = wait_with_timeout(&mut guard.0, TIMEOUT);

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -167,8 +167,17 @@ fn send(stdin: &mut ChildStdin, msg: &Value) {
 /// Read and parse the next response line, bounded by [`TIMEOUT`] so a
 /// stuck server fails this assertion instead of hanging the test binary.
 fn recv(rx: &Receiver<String>) -> Value {
+    recv_within(rx, TIMEOUT)
+}
+
+/// Like [`recv`], but with a caller-supplied bound instead of [`TIMEOUT`] —
+/// for the one scenario (a wedged socket client) whose fix is a *bounded*,
+/// but deliberately longer-than-[`TIMEOUT`], delay rather than an instant
+/// response, so that test needs its own wider window without loosening
+/// every other test's.
+fn recv_within(rx: &Receiver<String>, timeout: Duration) -> Value {
     let line = rx
-        .recv_timeout(TIMEOUT)
+        .recv_timeout(timeout)
         .expect("figmog serve did not respond within the timeout");
     serde_json::from_str(&line)
         .unwrap_or_else(|e| panic!("response line was not valid JSON: {e}\nline: {line}"))
@@ -1107,22 +1116,68 @@ fn default_root_fixture(key: &str, fixture: Value) -> tempfile::TempDir {
     dir
 }
 
-/// Spawn `figmog serve --no-watch --no-upstream <key>` against the default
-/// (cwd-relative) `.figmog` root, with `FIGMA_TOKEN` scrubbed — every
-/// socket-plane e2e test below runs the CLI half from the same `cwd`, so
-/// both sides derive the identical root/db paths a real deployment would.
+/// Like [`default_root_fixture`], but for several mirrored files under one
+/// root with `.figmog/current` pointed at a caller-chosen key — used by the
+/// C1 regression test proving socket-routed calls target *that* key, not
+/// whichever file `figmog serve` itself would pick as its own default.
+fn default_root_fixture_multi(entries: &[(&str, Value)], current: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let figmog_dir = dir.path().join(".figmog");
+    for (key, fixture) in entries {
+        let response = dir.path().join(format!("{key}.json"));
+        std::fs::write(&response, serde_json::to_string(fixture).unwrap()).unwrap();
+        let db = figmog_dir.join(key).join("db");
+        assert_cmd::Command::cargo_bin("figmog")
+            .unwrap()
+            .args(["pull", "--from-file"])
+            .arg(&response)
+            .arg("--db")
+            .arg(&db)
+            .assert()
+            .success();
+    }
+    std::fs::write(figmog_dir.join("current"), current).unwrap();
+    dir
+}
+
+/// Spawn `figmog serve --no-watch --no-upstream <keys...>` against the
+/// default (cwd-relative) `.figmog` root, with `FIGMA_TOKEN` scrubbed —
+/// every socket-plane e2e test below runs the CLI half from the same
+/// `cwd`, so both sides derive the identical root/db paths a real
+/// deployment would. `keys` may be empty (spec §14's zero-startup-file
+/// shape — the real quick-start invocation, `claude mcp add figmog --
+/// figmog serve`, always starts this way).
+fn spawn_default_root_serve_keys(
+    cwd: &std::path::Path,
+    keys: &[&str],
+    extra_args: &[&str],
+) -> (ChildGuard, ChildStdin, Receiver<String>) {
+    let bin = assert_cmd::cargo::cargo_bin("figmog");
+    let mut cmd = Command::new(bin);
+    cmd.args(["serve", "--no-watch", "--no-upstream"])
+        .args(keys)
+        .args(extra_args)
+        .current_dir(cwd)
+        .env_remove("FIGMA_TOKEN");
+    spawn_child(cmd)
+}
+
 fn spawn_default_root_serve(
     cwd: &std::path::Path,
     key: &str,
     extra_args: &[&str],
 ) -> (ChildGuard, ChildStdin, Receiver<String>) {
-    let bin = assert_cmd::cargo::cargo_bin("figmog");
-    let mut cmd = Command::new(bin);
-    cmd.args(["serve", "--no-watch", "--no-upstream", key])
-        .args(extra_args)
-        .current_dir(cwd)
-        .env_remove("FIGMA_TOKEN");
-    spawn_child(cmd)
+    spawn_default_root_serve_keys(cwd, &[key], extra_args)
+}
+
+/// Zero-startup-files variant of [`spawn_default_root_serve`] (spec §14:
+/// the server starts empty and mirrors files as agents/commands reference
+/// them).
+fn spawn_default_root_serve_zero_files(
+    cwd: &std::path::Path,
+    extra_args: &[&str],
+) -> (ChildGuard, ChildStdin, Receiver<String>) {
+    spawn_default_root_serve_keys(cwd, &[], extra_args)
 }
 
 /// The `initialize` / `notifications/initialized` handshake every stdio
@@ -1354,6 +1409,224 @@ fn stale_socket_file_is_unlinked_and_rebound() {
         std::os::unix::net::UnixStream::connect(&sock_path).is_ok(),
         "the rebound socket should accept a real connection"
     );
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
+// ---- review fix round: C1 (routed reads target `.figmog/current`,
+// not serve's own default), I1 (a wedged socket client can't freeze
+// stdio), m6 (direct vs. socket parity) ----
+
+/// C1 (reproduced by review, now fixed): two mirrored files, both given at
+/// startup — serve's own default is `FIRST` (the first startup FILE) — but
+/// `.figmog/current` (the fixture builder's last write) names `SECOND`.
+/// Before the fix, a socket-routed `figmog status` carried no `file`
+/// argument at all and silently answered from serve's own default
+/// (`FIRST`); the fix injects `.figmog/current`'s key so the routed call
+/// targets the *same* mirror direct mode would.
+#[test]
+fn socket_status_targets_current_mirror_not_servers_own_default() {
+    const FIRST: &str = "figmogsockparityaaa11";
+    const SECOND: &str = "figmogsockparitybbb22";
+    let dir = default_root_fixture_multi(
+        &[
+            (FIRST, common::fixture_v1()),
+            (SECOND, common::fixture_other()),
+        ],
+        SECOND,
+    );
+    let (mut guard, mut stdin, rx) =
+        spawn_default_root_serve_keys(dir.path(), &[FIRST, SECOND], &[]);
+    handshake(&mut stdin, &rx);
+
+    let out = assert_cmd::Command::cargo_bin("figmog")
+        .unwrap()
+        .arg("status")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let v: Value = serde_json::from_slice(&out.get_output().stdout).unwrap();
+    assert_eq!(
+        v["name"],
+        json!("OtherFixture"),
+        "expected the .figmog/current mirror (SECOND), not serve's own \
+         startup default (FIRST): {v}"
+    );
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
+/// C1 (reproduced by review, now fixed): the real quick-start shape — zero
+/// startup files (`figmog serve` with no file argument, exactly what
+/// `claude mcp add figmog -- figmog serve` runs), relying entirely on
+/// auto-open. Before the fix, a socket-routed `figmog status` with no
+/// `file` argument hit `SessionManager::resolve(None, ..)` against a
+/// server with *zero* sessions and no `default_key` — a hard "no default
+/// mirrored file" error, even though a mirror was already pulled and
+/// sitting on disk. The fix routes the injected `.figmog/current` key
+/// through the explicit-`file` path, which auto-opens it — the store is
+/// already mirrored (`meta_present`), so this costs no Tier-1 pull.
+#[test]
+fn socket_status_targets_the_current_mirror_with_zero_startup_files() {
+    const KEY: &str = "figmogsockzerofilesg1";
+    let dir = default_root_fixture(KEY, common::fixture_v1());
+    let (mut guard, mut stdin, rx) = spawn_default_root_serve_zero_files(dir.path(), &[]);
+    handshake(&mut stdin, &rx);
+
+    // Nothing mirrored yet from serve's own point of view.
+    let resp = call(&mut stdin, &rx, 2, "figmog_files", json!({}));
+    assert_eq!(result_json(&resp), json!([]));
+
+    let out = assert_cmd::Command::cargo_bin("figmog")
+        .unwrap()
+        .arg("status")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let v: Value = serde_json::from_slice(&out.get_output().stdout)
+        .unwrap_or_else(|e| panic!("stdout not JSON: {e}"));
+    assert!(
+        v.get("error").is_none(),
+        "expected real data, not the no-default-mirrored-file error: {v}"
+    );
+    assert_eq!(v["name"], json!("Fixture"));
+
+    // Proves it really auto-opened (spent no network, since the store was
+    // already mirrored) rather than answering from nowhere.
+    let resp = call(&mut stdin, &rx, 3, "figmog_files", json!({}));
+    let rows = result_json(&resp);
+    let rows = rows.as_array().unwrap();
+    assert_eq!(rows.len(), 1, "rows: {rows:#?}");
+    assert_eq!(rows[0]["key"], json!(KEY));
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
+/// I1 (reproduced by review, now fixed): a socket client that connects,
+/// sends a flood of requests, and never reads a single response back must
+/// not be able to freeze the single-threaded main loop — and therefore
+/// stdio — forever. Before the fix, `write_socket_response` held the
+/// `ConnRegistry` mutex across an unbounded blocking write; a client that
+/// never drains its receive buffer would eventually wedge that write (and
+/// every other connection's registry bookkeeping) indefinitely. After the
+/// fix, the write is bounded by `SOCKET_WRITE_TIMEOUT` (5s) and happens on
+/// a handle cloned out from behind the lock — this test proves stdio still
+/// gets answered within a bounded window (well under this test's own
+/// deadline) even while the wedged connection is being flooded.
+#[test]
+fn wedged_socket_client_does_not_freeze_stdio() {
+    const KEY: &str = "figmogsockwedgedkey01";
+    let dir = default_root_fixture(KEY, common::fixture_v1());
+    let (mut guard, mut stdin, rx) = spawn_default_root_serve(dir.path(), KEY, &[]);
+    handshake(&mut stdin, &rx);
+
+    let sock_path = dir.path().join(".figmog").join("serve.sock");
+    let mut wedged =
+        std::os::unix::net::UnixStream::connect(&sock_path).expect("connect the wedged client");
+
+    // Flood a single connection, never reading a single response, with
+    // enough total response *bytes* to exceed whatever the OS's send-buffer
+    // size for this connection happens to be (varies by platform — this
+    // doesn't assume a specific number, just "enough"). `figmog_subtree` on
+    // the whole document (full raw JSON, no depth/field limit) gives a much
+    // bigger response per call than e.g. `figmog_status` would, so this
+    // reaches the same total bytes with far fewer round trips — each
+    // round trip carries its own real per-call store-transaction cost on
+    // the server, which dominates this loop's own wall time far more than
+    // the actual socket write ever would.
+    for i in 0..300u32 {
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "id": i,
+            "method": "tools/call",
+            "params": {"name": "figmog_subtree", "arguments": {"id": "0:0"}},
+        });
+        if writeln!(wedged, "{frame}").is_err() {
+            break;
+        }
+    }
+    let _ = wedged.flush();
+
+    // Drive the SAME server over stdio while the wedged connection is
+    // still sitting there unread. `recv_within`'s bound here is
+    // deliberately much wider than `TIMEOUT`: this response sits queued
+    // behind every already-enqueued socket message (including whichever
+    // one's write blocks for up to `SOCKET_WRITE_TIMEOUT` before the fix's
+    // registry cleanup unwedges the loop) plus real processing time for
+    // the rest of that backlog — bounded, but not "instant". Before the
+    // fix (no write timeout at all) this would hang far past this bound
+    // instead of resolving.
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "figmog_status", "arguments": {}},
+        }),
+    );
+    let resp = recv_within(&rx, Duration::from_secs(30));
+    assert_eq!(resp["result"]["isError"], json!(false), "resp: {resp:#?}");
+
+    drop(wedged);
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, Duration::from_secs(30));
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
+/// m6: a handful of read commands (deliberately including `where
+/// --pointer` with no `--equals` — C2's exact regression shape — and
+/// `status` — m1's) run once direct (before serve ever starts, so the
+/// store is never locked) and once socket-routed (after serve starts
+/// against the very same on-disk data), asserting byte-identical JSON
+/// output either way.
+#[test]
+fn socket_routed_reads_are_byte_identical_to_direct_mode() {
+    const KEY: &str = "figmogsockparitykey01";
+    let dir = default_root_fixture(KEY, common::fixture_v1());
+
+    let commands: &[&[&str]] = &[
+        &["status"],
+        &["pages"],
+        &["tree"],
+        &["find", "--type", "TEXT"],
+        &["search", "garden"],
+        &["stats"],
+        &["where", "--pointer", "/layoutMode", "--equals", "VERTICAL"],
+        // The exact shape C2 regressed on: no `--equals` at all.
+        &["where", "--pointer", "/layoutMode"],
+    ];
+
+    let run = |args: &[&str]| -> Value {
+        let out = assert_cmd::Command::cargo_bin("figmog")
+            .unwrap()
+            .args(args)
+            .current_dir(dir.path())
+            .assert()
+            .success();
+        serde_json::from_slice(&out.get_output().stdout)
+            .unwrap_or_else(|e| panic!("{args:?} stdout not JSON: {e}"))
+    };
+
+    // Direct-mode baseline: captured before serve ever starts, so the
+    // store is never locked (no `--no-socket` needed — there's nothing to
+    // connect to yet either way).
+    let direct: Vec<Value> = commands.iter().map(|args| run(args)).collect();
+
+    let (mut guard, mut stdin, rx) = spawn_default_root_serve(dir.path(), KEY, &[]);
+    handshake(&mut stdin, &rx);
+
+    let socket: Vec<Value> = commands.iter().map(|args| run(args)).collect();
+
+    for (args, (d, s)) in commands.iter().zip(direct.iter().zip(socket.iter())) {
+        assert_eq!(d, s, "direct vs socket mismatch for {args:?}");
+    }
 
     drop(stdin);
     let status = wait_with_timeout(&mut guard.0, TIMEOUT);

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -261,15 +261,16 @@ fn serve_e2e_initialize_tools_list_and_tool_calls() {
         &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
     );
 
-    // -- tools/list: exactly 20 figmog_* tools (spec §14: the 17 v3 tools
-    // plus figmog_open/figmog_files, plus v0.0.2 §2's figmog_subtree) --
+    // -- tools/list: exactly 21 figmog_* tools (spec §14: the 17 v3 tools
+    // plus figmog_open/figmog_files, plus v0.0.2 §2's figmog_subtree and
+    // §5's figmog_images) --
     send(
         &mut stdin,
         &json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
     );
     let resp = recv(&rx);
     let tools = resp["result"]["tools"].as_array().expect("tools array");
-    assert_eq!(tools.len(), 20, "tools: {tools:#?}");
+    assert_eq!(tools.len(), 21, "tools: {tools:#?}");
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     for name in &names {
         assert!(
@@ -568,14 +569,14 @@ fn serve_e2e_proxied_tool_lists_round_trips_and_second_call_is_cache_served() {
         &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
     );
 
-    // -- tools/list: 20 local + 1 proxied, prefixed description --
+    // -- tools/list: 21 local + 1 proxied, prefixed description --
     send(
         &mut stdin,
         &json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
     );
     let resp = recv(&rx);
     let tools = resp["result"]["tools"].as_array().expect("tools array");
-    assert_eq!(tools.len(), 21, "tools: {tools:#?}");
+    assert_eq!(tools.len(), 22, "tools: {tools:#?}");
     let proxied = tools
         .iter()
         .find(|t| t["name"] == json!("get_code"))
@@ -657,7 +658,7 @@ fn serve_e2e_multi_file_routes_by_file_arg_and_first_startup_key_is_default() {
         &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
     );
 
-    // -- tools/list: 20 tools; every tool but figmog_open/figmog_files
+    // -- tools/list: 21 tools; every tool but figmog_open/figmog_files
     // carries an *optional* `file` property, figmog_open's `file` is
     // required, figmog_files takes none (spec §14). --
     send(
@@ -666,7 +667,7 @@ fn serve_e2e_multi_file_routes_by_file_arg_and_first_startup_key_is_default() {
     );
     let resp = recv(&rx);
     let tools = resp["result"]["tools"].as_array().expect("tools array");
-    assert_eq!(tools.len(), 20, "tools: {tools:#?}");
+    assert_eq!(tools.len(), 21, "tools: {tools:#?}");
     for tool in tools {
         let name = tool["name"].as_str().expect("tool name");
         let schema = &tool["inputSchema"];

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -46,6 +46,15 @@ fn spawn_serve(db: &std::path::Path) -> (ChildGuard, ChildStdin, Receiver<String
 
 /// Like [`spawn_serve`], but with extra CLI args after `--db <db>` (e.g.
 /// `--upstream <url>` for the proxy e2e test).
+///
+/// `current_dir` is pinned to `db`'s own tempdir (every caller's `db` is
+/// `<tempdir>/db` — see `common::fixture_db`): `figmog serve` binds its
+/// unix-socket control plane (spec §1) at `<figmog-root>/serve.sock`, and
+/// `--figmog-root` defaults to the cwd-relative `.figmog` regardless of
+/// `--db` — without this, every one of this file's `--db`-mode e2e tests
+/// (which never sets its own `current_dir`) would default to the *shared*
+/// `cargo test` process cwd, racing every other concurrently-running test
+/// in this binary to bind the exact same socket path.
 fn spawn_serve_with_args(
     db: &std::path::Path,
     extra_args: &[&str],
@@ -54,7 +63,8 @@ fn spawn_serve_with_args(
     let mut cmd = Command::new(bin);
     cmd.args(["serve", "--no-watch", "--db"])
         .arg(db)
-        .args(extra_args);
+        .args(extra_args)
+        .current_dir(db.parent().expect("db path has a parent tempdir"));
     spawn_child(cmd)
 }
 
@@ -1058,4 +1068,294 @@ fn serve_e2e_no_watch_default_root_startup_does_not_write_figmog_current() {
         !cwd.path().join(".figmog").join("current").exists(),
         "--no-watch startup against a pre-built store must not write .figmog/current"
     );
+}
+
+// ---- unix-socket control plane e2e (v0.0.2 spec §1) ----
+//
+// The CLI's own socket routing (`cli::socket`) only ever tries a root
+// derived exactly like `figmog serve`'s default: `.figmog` relative to the
+// current directory (it has no `--figmog-root` override — that's serve's
+// hidden testability knob). Every test below builds a root-derived fixture
+// store at `<cwd>/.figmog/<key>/db` (the same layout a real `figmog pull`
+// would leave) plus `<cwd>/.figmog/current`, then runs both `figmog serve`
+// and every CLI probe with `current_dir(cwd)` so the two sides agree on
+// the root.
+
+/// Build a root-derived fixture store at `<dir>/.figmog/<key>/db` — the
+/// exact path `sessions::open_session` derives for a startup FILE with no
+/// `--figmog-root` override — and establish `<dir>/.figmog/current`
+/// pointing at it (which `pull --from-file --db <path>` itself never
+/// writes, since `--db` short-circuits key tracking — see
+/// `cli::resolve_db`), matching what a real `figmog pull <url>` run from
+/// `dir` would leave behind. Returns the tempdir; the caller must keep it
+/// alive for the test's duration.
+fn default_root_fixture(key: &str, fixture: Value) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let response = dir.path().join("resp.json");
+    std::fs::write(&response, serde_json::to_string(&fixture).unwrap()).unwrap();
+    let figmog_dir = dir.path().join(".figmog");
+    let db = figmog_dir.join(key).join("db");
+    assert_cmd::Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["pull", "--from-file"])
+        .arg(&response)
+        .arg("--db")
+        .arg(&db)
+        .assert()
+        .success();
+    std::fs::write(figmog_dir.join("current"), key).unwrap();
+    dir
+}
+
+/// Spawn `figmog serve --no-watch --no-upstream <key>` against the default
+/// (cwd-relative) `.figmog` root, with `FIGMA_TOKEN` scrubbed — every
+/// socket-plane e2e test below runs the CLI half from the same `cwd`, so
+/// both sides derive the identical root/db paths a real deployment would.
+fn spawn_default_root_serve(
+    cwd: &std::path::Path,
+    key: &str,
+    extra_args: &[&str],
+) -> (ChildGuard, ChildStdin, Receiver<String>) {
+    let bin = assert_cmd::cargo::cargo_bin("figmog");
+    let mut cmd = Command::new(bin);
+    cmd.args(["serve", "--no-watch", "--no-upstream", key])
+        .args(extra_args)
+        .current_dir(cwd)
+        .env_remove("FIGMA_TOKEN");
+    spawn_child(cmd)
+}
+
+/// The `initialize` / `notifications/initialized` handshake every stdio
+/// e2e test in this file performs before its first real request — shared
+/// here since the socket-plane tests below still drive `figmog serve` over
+/// stdio (to prove it's alive and to close it down cleanly) alongside the
+/// socket-routed CLI calls under test.
+fn handshake(stdin: &mut ChildStdin, rx: &Receiver<String>) {
+    send(
+        stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2025-06-18", "capabilities": {}},
+        }),
+    );
+    let resp = recv(rx);
+    assert_eq!(resp["id"], json!(1));
+    send(
+        stdin,
+        &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+    );
+}
+
+/// (a) `figmog status` while `figmog serve` owns the store: reachable over
+/// the socket ⇒ fresh data, exit 0, no lock error at all (spec §1's
+/// headline fix — this is the exact friction the whole feature exists to
+/// remove).
+#[test]
+fn socket_status_returns_fresh_data_with_no_lock_error() {
+    const KEY: &str = "figmogsocketkeyaaa111";
+    let dir = default_root_fixture(KEY, common::fixture_v1());
+    let (mut guard, mut stdin, rx) = spawn_default_root_serve(dir.path(), KEY, &[]);
+    handshake(&mut stdin, &rx);
+
+    let out = assert_cmd::Command::cargo_bin("figmog")
+        .unwrap()
+        .arg("status")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let stdout = out.get_output().stdout.clone();
+    let v: Value = serde_json::from_slice(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not JSON: {e}\n{}", String::from_utf8_lossy(&stdout)));
+    assert!(v.get("error").is_none(), "unexpected error shape: {v}");
+    assert_eq!(v["name"], json!("Fixture"));
+    assert!(
+        v["nodes"].as_u64().unwrap_or(0) > 0,
+        "expected a nonzero node count: {v}"
+    );
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
+/// (b) `figmog call figmog_sync` reaches the *owning* process over the
+/// socket rather than failing against the local lock. `FIGMA_TOKEN` is
+/// scrubbed from `serve`'s own environment (`spawn_default_root_serve`),
+/// so its pull attempt fails with a specific, recognizable error — proving
+/// the error genuinely came from serve's own sync attempt (not a local
+/// store-lock panic, which this CLI invocation could never hit anyway,
+/// since it never opens the store directly when the socket is reachable)
+/// — and serve must stay alive and answering afterward.
+#[test]
+fn socket_call_figmog_sync_reaches_the_owning_process_not_a_local_lock_error() {
+    const KEY: &str = "figmogsocketkeybbb222";
+    let dir = default_root_fixture(KEY, common::fixture_v1());
+    let (mut guard, mut stdin, rx) = spawn_default_root_serve(dir.path(), KEY, &[]);
+    handshake(&mut stdin, &rx);
+
+    let out = assert_cmd::Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["call", "figmog_sync"])
+        .current_dir(dir.path())
+        .assert()
+        .failure();
+    let output = out.get_output();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected a clean exit-1 JSON error, not a lock panic; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: Value = serde_json::from_slice(&output.stderr).unwrap_or_else(|e| {
+        panic!(
+            "stderr must be exactly one JSON object (parse error: {e}); stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let err = parsed["error"]
+        .as_str()
+        .unwrap_or_else(|| panic!("expected an \"error\" string field, got: {parsed}"));
+    assert!(
+        err.contains("FIGMA_TOKEN not set"),
+        "expected serve's own sync error, got: {err}"
+    );
+    assert!(
+        !err.to_lowercase().contains("locked"),
+        "must not be a local store-lock error: {err}"
+    );
+
+    // serve is still alive and answering after that error.
+    let resp = call(&mut stdin, &rx, 2, "figmog_status", json!({}));
+    assert_eq!(resp["result"]["isError"], json!(false), "resp: {resp:#?}");
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
+/// (c) `--no-socket` forces the old direct-open path even with a reachable
+/// serve — reproducing the pre-v0.0.2 lock error exactly, on both the
+/// `serve` side (never listens) and the CLI side (never probes).
+#[test]
+fn no_socket_flag_forces_the_old_lock_error() {
+    const KEY: &str = "figmogsocketkeyccc333";
+    let dir = default_root_fixture(KEY, common::fixture_v1());
+    let (mut guard, mut stdin, rx) = spawn_default_root_serve(dir.path(), KEY, &[]);
+    handshake(&mut stdin, &rx);
+
+    let out = assert_cmd::Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["status", "--no-socket"])
+        .current_dir(dir.path())
+        .assert()
+        .failure();
+    let output = out.get_output();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: Value = serde_json::from_slice(&output.stderr).unwrap();
+    let err = parsed["error"].as_str().unwrap();
+    assert!(
+        err.contains("store is locked"),
+        "expected the direct-mode lock error, got: {err}"
+    );
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
+/// (d) A clean stdin-EOF exit removes `serve.sock` — the socket file must
+/// not outlive the process that created it.
+#[test]
+fn clean_exit_removes_serve_sock() {
+    const KEY: &str = "figmogsocketkeyddd444";
+    let dir = default_root_fixture(KEY, common::fixture_v1());
+    let (mut guard, mut stdin, rx) = spawn_default_root_serve(dir.path(), KEY, &[]);
+    handshake(&mut stdin, &rx);
+
+    let sock_path = dir.path().join(".figmog").join("serve.sock");
+    assert!(
+        sock_path.exists(),
+        "socket file should exist while serve is running"
+    );
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+
+    assert!(
+        !sock_path.exists(),
+        "socket file should be removed on clean exit"
+    );
+}
+
+/// (e) A second `figmog serve` against the same root, while the first is
+/// still alive, exits with the clean JSON "another figmog serve owns this
+/// root" error — never stealing the socket. Started with zero startup
+/// files so its own session-store open (a separate concern, spec §1's I-1)
+/// can never race the socket check and mask it with a store-lock error
+/// instead.
+#[test]
+fn second_serve_on_same_root_exits_with_clean_error() {
+    const KEY: &str = "figmogsocketkeyeee555";
+    let dir = default_root_fixture(KEY, common::fixture_v1());
+    let (mut guard, mut stdin, rx) = spawn_default_root_serve(dir.path(), KEY, &[]);
+    handshake(&mut stdin, &rx);
+
+    let out = assert_cmd::Command::cargo_bin("figmog")
+        .unwrap()
+        .args(["serve", "--no-watch", "--no-upstream"])
+        .current_dir(dir.path())
+        .env_remove("FIGMA_TOKEN")
+        .assert()
+        .failure();
+    let output = out.get_output();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: Value = serde_json::from_slice(&output.stderr).unwrap_or_else(|e| {
+        panic!(
+            "stderr must be exactly one JSON object (parse error: {e}); stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let err = parsed["error"].as_str().unwrap();
+    assert!(
+        err.contains("another figmog serve owns this root"),
+        "expected the clean multi-owner error, got: {err}"
+    );
+
+    // The first serve is untouched by the second's failed startup.
+    let resp = call(&mut stdin, &rx, 2, "figmog_status", json!({}));
+    assert_eq!(resp["result"]["isError"], json!(false), "resp: {resp:#?}");
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
+/// (f) A stale socket file (nothing listening behind it — the simplest
+/// reproduction of a leftover from an unclean exit) is unlinked and
+/// rebound at startup, proven by a real client successfully connecting to
+/// the *new* socket afterward.
+#[test]
+fn stale_socket_file_is_unlinked_and_rebound() {
+    let dir = tempfile::tempdir().unwrap();
+    let figmog_dir = dir.path().join(".figmog");
+    std::fs::create_dir_all(&figmog_dir).unwrap();
+    let sock_path = figmog_dir.join("serve.sock");
+    std::fs::write(&sock_path, b"not a socket, nothing listening here").unwrap();
+
+    let (mut guard, mut stdin, rx) =
+        spawn_default_root_serve(dir.path(), "figmogstalekeyfff666", &[]);
+    handshake(&mut stdin, &rx);
+
+    assert!(sock_path.exists(), "a real socket should now be bound");
+    assert!(
+        std::os::unix::net::UnixStream::connect(&sock_path).is_ok(),
+        "the rebound socket should accept a real connection"
+    );
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
 }

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -876,6 +876,81 @@ fn serve_e2e_zero_startup_url_id_infers_the_file_and_resolves_the_node() {
     assert!(status.success(), "figmog serve exited with {status:?}");
 }
 
+/// Review fix I3: the explicit-`file`/URL-file mismatch note (spec §2b)
+/// must compare *normalized* file keys, not raw argument text — an
+/// explicit `file` that's itself a full Figma URL naming the very same
+/// file the `id` URL names is not a disagreement, even though the two
+/// strings look nothing alike. A genuinely different explicit `file` still
+/// gets the note.
+#[test]
+fn serve_e2e_mismatch_note_compares_normalized_file_keys() {
+    let root = build_fixture_root(&[
+        (KEY_A, common::fixture_v1()),
+        (KEY_B, common::fixture_other()),
+    ]);
+    let (mut guard, mut stdin, rx) = spawn_serve_multifile(root.path(), &[]);
+
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2025-06-18", "capabilities": {}},
+        }),
+    );
+    let resp = recv(&rx);
+    assert_eq!(resp["id"], json!(1));
+    send(
+        &mut stdin,
+        &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+    );
+
+    // Same file, different spelling: explicit `file` is a full URL naming
+    // KEY_A, `id` is a *different* full URL also naming KEY_A (with an
+    // unknown node id, so the call still fails) — no mismatch, no note.
+    let same_file_url = format!("https://www.figma.com/design/{KEY_A}/Alt-Name");
+    let id_url_a = format!("https://www.figma.com/file/{KEY_A}/Fixture?node-id=99-99");
+    let resp = call(
+        &mut stdin,
+        &rx,
+        2,
+        "figmog_node",
+        json!({"id": id_url_a, "file": same_file_url}),
+    );
+    assert_eq!(resp["result"]["isError"], json!(true));
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(text.contains("99:99"), "text: {text}");
+    assert!(
+        !text.contains("note:"),
+        "same file, different spelling: no mismatch note expected — text: {text}"
+    );
+
+    // Genuinely different files: explicit `file` names KEY_A, `id` is a
+    // URL naming KEY_B — the note must appear and name both keys.
+    let id_url_b = format!("https://www.figma.com/design/{KEY_B}/Other?node-id=99-99");
+    let resp = call(
+        &mut stdin,
+        &rx,
+        3,
+        "figmog_node",
+        json!({"id": id_url_b, "file": KEY_A}),
+    );
+    assert_eq!(resp["result"]["isError"], json!(true));
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(text.contains("note:"), "text: {text}");
+    assert!(text.contains(KEY_A), "text: {text}");
+    assert!(text.contains(KEY_B), "text: {text}");
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
 /// `--db <path>` with no FILE positional predates multi-file serve (spec
 /// §14 non-goal: CLI multi-file addressing is out of scope) — the single
 /// session it opens has no real Figma key to pull with (see

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -242,15 +242,15 @@ fn serve_e2e_initialize_tools_list_and_tool_calls() {
         &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
     );
 
-    // -- tools/list: exactly 19 figmog_* tools (spec §14: the 17 v3 tools
-    // plus figmog_open/figmog_files) --
+    // -- tools/list: exactly 20 figmog_* tools (spec §14: the 17 v3 tools
+    // plus figmog_open/figmog_files, plus v0.0.2 §2's figmog_subtree) --
     send(
         &mut stdin,
         &json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
     );
     let resp = recv(&rx);
     let tools = resp["result"]["tools"].as_array().expect("tools array");
-    assert_eq!(tools.len(), 19, "tools: {tools:#?}");
+    assert_eq!(tools.len(), 20, "tools: {tools:#?}");
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     for name in &names {
         assert!(
@@ -549,14 +549,14 @@ fn serve_e2e_proxied_tool_lists_round_trips_and_second_call_is_cache_served() {
         &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
     );
 
-    // -- tools/list: 19 local + 1 proxied, prefixed description --
+    // -- tools/list: 20 local + 1 proxied, prefixed description --
     send(
         &mut stdin,
         &json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
     );
     let resp = recv(&rx);
     let tools = resp["result"]["tools"].as_array().expect("tools array");
-    assert_eq!(tools.len(), 20, "tools: {tools:#?}");
+    assert_eq!(tools.len(), 21, "tools: {tools:#?}");
     let proxied = tools
         .iter()
         .find(|t| t["name"] == json!("get_code"))
@@ -607,7 +607,7 @@ fn serve_e2e_proxied_tool_lists_round_trips_and_second_call_is_cache_served() {
 //
 // Two pre-built stores under a temp `--figmog-root` (built via `pull
 // --from-file --db <root>/<key>/db`, never touching the network), started
-// with BOTH keys as positional args, proves the whole v4 surface: 19 tools,
+// with BOTH keys as positional args, proves the whole v4 surface: 20 tools,
 // every local tool's optional `file` schema property, `figmog_files`,
 // `file`-argument routing to a *specific* mirror, default-file routing on
 // an omitted `file`, and `figmog_open`'s isError on a missing token. A
@@ -638,7 +638,7 @@ fn serve_e2e_multi_file_routes_by_file_arg_and_first_startup_key_is_default() {
         &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
     );
 
-    // -- tools/list: 19 tools; every tool but figmog_open/figmog_files
+    // -- tools/list: 20 tools; every tool but figmog_open/figmog_files
     // carries an *optional* `file` property, figmog_open's `file` is
     // required, figmog_files takes none (spec §14). --
     send(
@@ -647,7 +647,7 @@ fn serve_e2e_multi_file_routes_by_file_arg_and_first_startup_key_is_default() {
     );
     let resp = recv(&rx);
     let tools = resp["result"]["tools"].as_array().expect("tools array");
-    assert_eq!(tools.len(), 19, "tools: {tools:#?}");
+    assert_eq!(tools.len(), 20, "tools: {tools:#?}");
     for tool in tools {
         let name = tool["name"].as_str().expect("tool name");
         let schema = &tool["inputSchema"];
@@ -800,6 +800,76 @@ fn serve_e2e_multi_file_zero_startup_omitted_file_errors_naming_figmog_open() {
         text.contains("figmog_files"),
         "error should name figmog_files: {text}"
     );
+
+    drop(stdin);
+    let status = wait_with_timeout(&mut guard.0, TIMEOUT);
+    assert!(status.success(), "figmog serve exited with {status:?}");
+}
+
+/// spec §2b: a full Figma frame URL works directly as `id` on
+/// `figmog_node`/`figmog_subtree`, and — with no explicit `file` argument
+/// and no startup default (zero startup files here) — the URL's own file
+/// key auto-opens the right mirror (spec §14's existing auto-open
+/// semantics), exactly as if `file: KEY_A` had been passed explicitly.
+/// The mirror's store already exists on disk (pre-built by
+/// `build_fixture_root`), so this never touches the network.
+#[test]
+fn serve_e2e_zero_startup_url_id_infers_the_file_and_resolves_the_node() {
+    let root = build_fixture_root(&[(KEY_A, common::fixture_v1())]);
+    let (mut guard, mut stdin, rx) = spawn_serve_multifile(root.path(), &[]);
+
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2025-06-18", "capabilities": {}},
+        }),
+    );
+    let resp = recv(&rx);
+    assert_eq!(resp["id"], json!(1));
+    send(
+        &mut stdin,
+        &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+    );
+
+    // Nothing mirrored yet — the store on disk hasn't been opened as a
+    // session until a tool call names it.
+    let resp = call(&mut stdin, &rx, 2, "figmog_files", json!({}));
+    assert_eq!(result_json(&resp), json!([]));
+
+    let url = format!("https://www.figma.com/design/{KEY_A}/Fixture?node-id=1-1&t=abc-1");
+
+    // figmog_node: `id` alone (no `file`) resolves the Hero frame from
+    // KEY_A's mirror.
+    let resp = call(&mut stdin, &rx, 3, "figmog_node", json!({"id": url}));
+    assert_eq!(resp["result"]["isError"], json!(false), "resp: {resp:#?}");
+    let node = result_json(&resp);
+    assert_eq!(node["id"], json!("1:1"));
+    assert_eq!(node["name"], json!("Hero"));
+
+    // figmog_subtree: same URL, still no `file` — proves the auto-open
+    // isn't a one-shot fluke of the first call above.
+    let resp = call(
+        &mut stdin,
+        &rx,
+        4,
+        "figmog_subtree",
+        json!({"id": url, "depth": 0}),
+    );
+    assert_eq!(resp["result"]["isError"], json!(false), "resp: {resp:#?}");
+    let subtree = result_json(&resp);
+    assert_eq!(subtree["id"], json!("1:1"));
+    assert_eq!(subtree["children"], json!([]));
+
+    // The URL's file key really did auto-open a session, not answer from
+    // thin air.
+    let resp = call(&mut stdin, &rx, 5, "figmog_files", json!({}));
+    let rows = result_json(&resp);
+    let rows = rows.as_array().expect("files array");
+    assert_eq!(rows.len(), 1, "files: {rows:#?}");
+    assert_eq!(rows[0]["key"], json!(KEY_A));
 
     drop(stdin);
     let status = wait_with_timeout(&mut guard.0, TIMEOUT);

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -69,6 +69,7 @@ fn initial_pull_populates_every_sink() {
             _colls,
             meta,
             _cache,
+            _mirror_config,
         )| {
             assert_eq!(nodes.iter().count(), 12);
             assert_eq!(nodes.get(&"1:2".to_string()).unwrap().name, "Title");
@@ -145,7 +146,7 @@ fn reopen_resumes_persisted_state() {
         sync(&mut st, &BTreeSet::new(), &flattened, 1_000);
     }
     let st = figmog::open_store!(&db);
-    st.rtx(|((nodes, ..), _, _, _, _, _, _, _)| {
+    st.rtx(|((nodes, ..), _, _, _, _, _, _, _, _)| {
         assert_eq!(nodes.iter().count(), 12);
     });
 }
@@ -169,7 +170,7 @@ fn v1_to_v2_minimal_churn_and_index_consistency() {
     pull(&mut st, &common::fixture_v1());
 
     let prior = st.rtx(
-        |((nodes, ..), components, component_sets, styles, _, _, _, _)| {
+        |((nodes, ..), components, component_sets, styles, _, _, _, _, _)| {
             figmog::store::collect_sweepable(&nodes, &components, &component_sets, &styles)
         },
     );
@@ -201,6 +202,7 @@ fn v1_to_v2_minimal_churn_and_index_consistency() {
             _vc,
             meta,
             _cache,
+            _mirror_config,
         )| {
             // rename re-indexed in bm25
             assert!(text.search("Headline", 5).iter().any(|h| h.val == "1:2"));
@@ -262,12 +264,12 @@ fn sweep_never_touches_variables() {
         );
     });
     let prior = st.rtx(
-        |((nodes, ..), components, component_sets, styles, _, _, _, _)| {
+        |((nodes, ..), components, component_sets, styles, _, _, _, _, _)| {
             figmog::store::collect_sweepable(&nodes, &components, &component_sets, &styles)
         },
     );
     pull_with_sweep(&mut st, &common::fixture_v2(), prior, 2_000);
-    st.rtx(|(_, _, _, _, vars, colls, _, _)| {
+    st.rtx(|(_, _, _, _, vars, colls, _, _, _)| {
         assert!(vars.get(&"VariableID:100".to_string()).is_some());
         assert!(colls.get(&"VC:1".to_string()).is_some());
     });
@@ -305,7 +307,7 @@ fn panicking_transaction_rolls_back_entirely() {
         })
     }));
     assert!(result.is_err());
-    st.rtx(|((nodes, ..), _, _, _, _, _, meta, _)| {
+    st.rtx(|((nodes, ..), _, _, _, _, _, meta, _, _)| {
         assert!(
             nodes.get(&"9:9".to_string()).is_none(),
             "aborted upsert must not persist"
@@ -349,7 +351,7 @@ fn proxy_cache_survives_same_version_and_is_evicted_on_version_change() {
     figmog::cache::store(&mut st, tool, args, "100", &content).unwrap();
 
     // Cache row present right after the write.
-    st.rtx(|(_, _, _, _, _, _, _, cache)| {
+    st.rtx(|(_, _, _, _, _, _, _, cache, _)| {
         assert_eq!(
             figmog::cache::lookup(&cache, tool, args, "100"),
             Some(content.clone())
@@ -359,7 +361,7 @@ fn proxy_cache_survives_same_version_and_is_evicted_on_version_change() {
     // Identical re-pull: file version unchanged -> cache row must survive,
     // and so must the imported variable.
     pull(&mut st, &common::fixture_v1());
-    st.rtx(|(_, _, _, _, vars, _, _, cache)| {
+    st.rtx(|(_, _, _, _, vars, _, _, cache, _)| {
         assert_eq!(
             figmog::cache::lookup(&cache, tool, args, "100"),
             Some(content.clone()),
@@ -370,7 +372,7 @@ fn proxy_cache_survives_same_version_and_is_evicted_on_version_change() {
 
     // v1 -> v2 pull (version "100" -> "101") with the sweep enabled.
     let prior = st.rtx(
-        |((nodes, ..), components, component_sets, styles, _, _, _, _)| {
+        |((nodes, ..), components, component_sets, styles, _, _, _, _, _)| {
             figmog::store::collect_sweepable(&nodes, &components, &component_sets, &styles)
         },
     );
@@ -378,14 +380,14 @@ fn proxy_cache_survives_same_version_and_is_evicted_on_version_change() {
 
     // The cache row is now stale (its file_version is still "100").
     let stale =
-        st.rtx(|(_, _, _, _, _, _, _, cache)| figmog::store::stale_cache_ids(&cache, "101"));
+        st.rtx(|(_, _, _, _, _, _, _, cache, _)| figmog::store::stale_cache_ids(&cache, "101"));
     assert_eq!(
         stale,
         vec![Id::ProxyCache(figmog::cache::cache_key(tool, args))]
     );
     figmog::store::evict_stale_cache(&mut st, &stale);
 
-    st.rtx(|(_, _, _, _, vars, _, _, cache)| {
+    st.rtx(|(_, _, _, _, vars, _, _, cache, _)| {
         assert!(
             figmog::cache::lookup(&cache, tool, args, "101").is_none(),
             "stale cache row must be gone after eviction"

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -70,6 +70,7 @@ fn initial_pull_populates_every_sink() {
             meta,
             _cache,
             _mirror_config,
+            _images,
         )| {
             assert_eq!(nodes.iter().count(), 12);
             assert_eq!(nodes.get(&"1:2".to_string()).unwrap().name, "Title");
@@ -146,7 +147,7 @@ fn reopen_resumes_persisted_state() {
         sync(&mut st, &BTreeSet::new(), &flattened, 1_000);
     }
     let st = figmog::open_store!(&db);
-    st.rtx(|((nodes, ..), _, _, _, _, _, _, _, _)| {
+    st.rtx(|((nodes, ..), _, _, _, _, _, _, _, _, _)| {
         assert_eq!(nodes.iter().count(), 12);
     });
 }
@@ -170,7 +171,7 @@ fn v1_to_v2_minimal_churn_and_index_consistency() {
     pull(&mut st, &common::fixture_v1());
 
     let prior = st.rtx(
-        |((nodes, ..), components, component_sets, styles, _, _, _, _, _)| {
+        |((nodes, ..), components, component_sets, styles, _, _, _, _, _, _)| {
             figmog::store::collect_sweepable(&nodes, &components, &component_sets, &styles)
         },
     );
@@ -203,6 +204,7 @@ fn v1_to_v2_minimal_churn_and_index_consistency() {
             meta,
             _cache,
             _mirror_config,
+            _images,
         )| {
             // rename re-indexed in bm25
             assert!(text.search("Headline", 5).iter().any(|h| h.val == "1:2"));
@@ -264,12 +266,12 @@ fn sweep_never_touches_variables() {
         );
     });
     let prior = st.rtx(
-        |((nodes, ..), components, component_sets, styles, _, _, _, _, _)| {
+        |((nodes, ..), components, component_sets, styles, _, _, _, _, _, _)| {
             figmog::store::collect_sweepable(&nodes, &components, &component_sets, &styles)
         },
     );
     pull_with_sweep(&mut st, &common::fixture_v2(), prior, 2_000);
-    st.rtx(|(_, _, _, _, vars, colls, _, _, _)| {
+    st.rtx(|(_, _, _, _, vars, colls, _, _, _, _)| {
         assert!(vars.get(&"VariableID:100".to_string()).is_some());
         assert!(colls.get(&"VC:1".to_string()).is_some());
     });
@@ -307,7 +309,7 @@ fn panicking_transaction_rolls_back_entirely() {
         })
     }));
     assert!(result.is_err());
-    st.rtx(|((nodes, ..), _, _, _, _, _, meta, _, _)| {
+    st.rtx(|((nodes, ..), _, _, _, _, _, meta, _, _, _)| {
         assert!(
             nodes.get(&"9:9".to_string()).is_none(),
             "aborted upsert must not persist"
@@ -351,7 +353,7 @@ fn proxy_cache_survives_same_version_and_is_evicted_on_version_change() {
     figmog::cache::store(&mut st, tool, args, "100", &content).unwrap();
 
     // Cache row present right after the write.
-    st.rtx(|(_, _, _, _, _, _, _, cache, _)| {
+    st.rtx(|(_, _, _, _, _, _, _, cache, _, _)| {
         assert_eq!(
             figmog::cache::lookup(&cache, tool, args, "100"),
             Some(content.clone())
@@ -361,7 +363,7 @@ fn proxy_cache_survives_same_version_and_is_evicted_on_version_change() {
     // Identical re-pull: file version unchanged -> cache row must survive,
     // and so must the imported variable.
     pull(&mut st, &common::fixture_v1());
-    st.rtx(|(_, _, _, _, vars, _, _, cache, _)| {
+    st.rtx(|(_, _, _, _, vars, _, _, cache, _, _)| {
         assert_eq!(
             figmog::cache::lookup(&cache, tool, args, "100"),
             Some(content.clone()),
@@ -372,7 +374,7 @@ fn proxy_cache_survives_same_version_and_is_evicted_on_version_change() {
 
     // v1 -> v2 pull (version "100" -> "101") with the sweep enabled.
     let prior = st.rtx(
-        |((nodes, ..), components, component_sets, styles, _, _, _, _, _)| {
+        |((nodes, ..), components, component_sets, styles, _, _, _, _, _, _)| {
             figmog::store::collect_sweepable(&nodes, &components, &component_sets, &styles)
         },
     );
@@ -380,14 +382,14 @@ fn proxy_cache_survives_same_version_and_is_evicted_on_version_change() {
 
     // The cache row is now stale (its file_version is still "100").
     let stale =
-        st.rtx(|(_, _, _, _, _, _, _, cache, _)| figmog::store::stale_cache_ids(&cache, "101"));
+        st.rtx(|(_, _, _, _, _, _, _, cache, _, _)| figmog::store::stale_cache_ids(&cache, "101"));
     assert_eq!(
         stale,
         vec![Id::ProxyCache(figmog::cache::cache_key(tool, args))]
     );
     figmog::store::evict_stale_cache(&mut st, &stale);
 
-    st.rtx(|(_, _, _, _, vars, _, _, cache, _)| {
+    st.rtx(|(_, _, _, _, vars, _, _, cache, _, _)| {
         assert!(
             figmog::cache::lookup(&cache, tool, args, "101").is_none(),
             "stale cache row must be gone after eviction"
@@ -399,6 +401,71 @@ fn proxy_cache_survives_same_version_and_is_evicted_on_version_change() {
         assert!(
             vars.get(&"VariableID:100".to_string()).is_some(),
             "cache eviction must never touch sweep-exempt variables"
+        );
+    });
+}
+
+/// `images` rows (v0.0.2 spec §5) join the exact same version-triggered
+/// eviction path as `proxy_cache` (`stale_image_ids` / `evict_stale_cache`
+/// — see the test right above this one for the `proxy_cache` half): a
+/// row survives a same-version repull and is evicted, record-level, once
+/// the file version moves on.
+#[test]
+fn image_blob_survives_same_version_and_is_evicted_on_version_change() {
+    use figmog::images::image_key;
+    use figmog::model::ImageBlobRec;
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut st = figmog::open_store!(dir.path().join("db"));
+    pull(&mut st, &common::fixture_v1());
+
+    let key = image_key("render", "1:2", "png", 1000);
+    let rec = ImageBlobRec {
+        key_hash: key.clone(),
+        kind: "render".into(),
+        subject: "1:2".into(),
+        format: "png".into(),
+        scale_milli: 1000,
+        file_version: "100".into(),
+        bytes: vec![1, 2, 3, 4],
+    };
+    st.wtx(|tx| {
+        tx.upsert(&Id::ImageBlob(key.clone()), &Rec::ImageBlob(rec.clone()));
+    });
+
+    // Row present right after the write.
+    st.rtx(|(_, _, _, _, _, _, _, _, _, images)| {
+        assert_eq!(images.get(&key), Some(rec.clone()));
+    });
+
+    // Identical re-pull: file version unchanged -> row must survive.
+    pull(&mut st, &common::fixture_v1());
+    st.rtx(|(_, _, _, _, _, _, _, _, _, images)| {
+        assert_eq!(
+            images.get(&key),
+            Some(rec.clone()),
+            "image row must survive a same-version repull"
+        );
+    });
+
+    // v1 -> v2 pull (version "100" -> "101") with the sweep enabled.
+    let prior = st.rtx(
+        |((nodes, ..), components, component_sets, styles, _, _, _, _, _, _)| {
+            figmog::store::collect_sweepable(&nodes, &components, &component_sets, &styles)
+        },
+    );
+    pull_with_sweep(&mut st, &common::fixture_v2(), prior, 2_000);
+
+    // The row is now stale (its file_version is still "100").
+    let stale = st
+        .rtx(|(_, _, _, _, _, _, _, _, _, images)| figmog::store::stale_image_ids(&images, "101"));
+    assert_eq!(stale, vec![Id::ImageBlob(key.clone())]);
+    figmog::store::evict_stale_cache(&mut st, &stale);
+
+    st.rtx(|(_, _, _, _, _, _, _, _, _, images)| {
+        assert!(
+            images.get(&key).is_none(),
+            "stale image row must be gone after eviction"
         );
     });
 }


### PR DESCRIPTION
Field feedback from a design agent building a replica surfaced six ergonomic gaps (the mirror's fidelity was never the problem). This PR fixes all six plus a friendlier README:

1. **Socket control plane** — CLI reads become clients of a running `serve` over `<root>/serve.sock`; the store-locked error becomes nearly unreachable.
2. **`figmog dump` / `figmog_subtree`** — full-fidelity subtree export with `--depth` and `--fields` projection (one call instead of 204).
3. **`--under <id>`** subtree scoping on `text`/`find`/`search`/`where`.
4. **Sticky `pull --geometry`** — vector path data, per-mirror stickiness via a new (append-only) MirrorConfig record.
5. **`figmog images` / `figmog_images`** — node renders + image fills, version-cached in a new `images` sink; explicit-only budget spend.
6. **`--resolve-vars`** — design-token names joined onto bound values at read time.
7. **README rewrite** — leads with the positioning: a superset of the Figma MCP surface for high-performance design agents; depth moves to docs/SPEC.md.

Spec: docs/specs/2026-08-17-v0.0.2-ergonomics.md. Task commits land on this branch with per-task adversarial reviews; final whole-PR review before merge; v0.0.2 pre-release tagged from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)